### PR TITLE
Add __wrapper_version__

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -21,6 +21,8 @@ Usage:
 import os
 import sys
 
+__version__ = "0.2.3"
+
 
 def _pyqt5():
     import PyQt5.Qt
@@ -31,6 +33,7 @@ def _pyqt5():
     PyQt5.QtCore.Property = PyQt5.QtCore.pyqtProperty
 
     # Add
+    PyQt5.__wrapper_version__ = __version__
     PyQt5.__binding__ = "PyQt5"
     PyQt5.__binding_version__ = PyQt5.QtCore.PYQT_VERSION_STR
     PyQt5.__qt_version__ = PyQt5.QtCore.PYQT_VERSION_STR
@@ -49,6 +52,7 @@ def _pyqt4():
     PyQt4.QtCore.Property = PyQt4.QtCore.pyqtProperty
 
     # Add
+    PyQt4.__wrapper_version__ = __version__
     PyQt4.__binding__ = "PyQt4"
     PyQt4.__binding_version__ = PyQt4.QtCore.PYQT_VERSION_STR
     PyQt4.__qt_version__ = PyQt4.QtCore.PYQT_VERSION_STR
@@ -60,6 +64,7 @@ def _pyside2():
     import PySide2
 
     # Add
+    PySide2.__wrapper_version__ = __version__
     PySide2.__binding__ = "PySide2"
     PySide2.__binding_version__ = PySide2.__version__
     PySide2.__qt_version__ = PySide2.QtCore.qVersion()
@@ -77,6 +82,7 @@ def _pyside():
     PySide.QtCore.QSortFilterProxyModel = PySide.QtGui.QSortFilterProxyModel
 
     # Add
+    PySide.__wrapper_version__ = __version__
     PySide.__binding__ = "PySide"
     PySide.__binding_version__ = PySide.__version__
     PySide.__qt_version__ = PySide.QtCore.qVersion()

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Qt.__qt_version__ == '5.6.1'
 Qt.__binding_version__ == '1.2.6'
 
 # Version of this project
-Qt.__version__ == '1.0.0'
+Qt.__wrapper_version__ == '1.0.0'
 ```
 
 **Branch binding-specific code**

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
+import sys
 from setuptools import setup
 
-version = "0.2.2"
+sys.modules["PySide2"] = None  # Mock module for successful import
+version = __import__("Qt").__wrapper_version__
 
 
 classifiers = [


### PR DESCRIPTION
Shouldn't use `__version__`, because it might be confused with the `__version__` of the binding.

```bash
$ python -c "import Qt;print(Qt);print(Qt.__version__)"
<module 'PySide' from 'C:\Python27\lib\site-packages\PySide\__init__.pyc'>
1.2.4
```