### PR TITLE
Provide Qt.load_ui

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -21,7 +21,7 @@ Usage:
 import os
 import sys
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 
 def _pyqt5():
@@ -133,6 +133,12 @@ def _init():
     preferred = os.getenv("QT_PREFERRED_BINDING")
 
     if preferred:
+
+        # Debug mode, used in installer
+        if preferred == "None":
+            sys.modules[__name__].__wrapper_version__ = __version__
+            return
+
         available = {
             "PySide2": _pyside2,
             "PySide": _pyside,

--- a/Qt.py
+++ b/Qt.py
@@ -26,13 +26,13 @@ __version__ = "0.2.4"
 
 def _pyqt5():
     import PyQt5.Qt
+    from PyQt5 import uic
 
     # Remap
     PyQt5.QtCore.Signal = PyQt5.QtCore.pyqtSignal
     PyQt5.QtCore.Slot = PyQt5.QtCore.pyqtSlot
     PyQt5.QtCore.Property = PyQt5.QtCore.pyqtProperty
 
-    from PyQt5 import uic
     PyQt5.load_ui = uic.loadUi
 
     # Add
@@ -46,6 +46,7 @@ def _pyqt5():
 
 def _pyqt4():
     import PyQt4.Qt
+    from PyQt4 import uic
 
     # Remap
     PyQt4.QtWidgets = PyQt4.QtGui
@@ -54,7 +55,6 @@ def _pyqt4():
     PyQt4.QtCore.Slot = PyQt4.QtCore.pyqtSlot
     PyQt4.QtCore.Property = PyQt4.QtCore.pyqtProperty
 
-    from PyQt4 import uic
     PyQt4.load_ui = uic.loadUi
 
     # Add

--- a/Qt.py
+++ b/Qt.py
@@ -68,6 +68,7 @@ def _pyqt4():
 
 def _pyside2():
     import PySide2
+    from PySide2 import QtUiTools
 
     # Add
     PySide2.__wrapper_version__ = __version__
@@ -79,11 +80,10 @@ def _pyside2():
     def load_ui(ui_filepath, *args, **kwargs):
         """Wrap QtUiTools.QUiLoader().load()
         for compatibility against PyQt5.uic.loadUi()
-        
+
         Args:
             ui_filepath (str): The filepath to the .ui file
         """
-        from PySide2 import QtUiTools
         return QtUiTools.QUiLoader().load(ui_filepath)
     PySide2.load_ui = load_ui
 
@@ -93,6 +93,7 @@ def _pyside2():
 def _pyside():
     import PySide
     import PySide.QtGui
+    from PySide import QtUiTools
 
     # Remap
     PySide.QtWidgets = PySide.QtGui
@@ -102,11 +103,10 @@ def _pyside():
     def load_ui(ui_filepath, *args, **kwargs):
         """Wrap QtUiTools.QUiLoader().load()
         for compatibility against PyQt4.uic.loadUi()
-        
+
         Args:
             ui_filepath (str): The filepath to the .ui file
         """
-        from PySide import QtUiTools
         return QtUiTools.QUiLoader().load(ui_filepath)
     PySide.load_ui = load_ui
 

--- a/Qt.py
+++ b/Qt.py
@@ -101,7 +101,7 @@ def _pyside():
 
     def load_ui(ui_filepath, *args, **kwargs):
         """Wrap QtUiTools.QUiLoader().load()
-        for compatibility against PyQt5.uic.loadUi()
+        for compatibility against PyQt4.uic.loadUi()
         
         Args:
             ui_filepath (str): The filepath to the .ui file

--- a/Qt.py
+++ b/Qt.py
@@ -21,7 +21,7 @@ Usage:
 import os
 import sys
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 
 def _pyqt5():
@@ -31,6 +31,9 @@ def _pyqt5():
     PyQt5.QtCore.Signal = PyQt5.QtCore.pyqtSignal
     PyQt5.QtCore.Slot = PyQt5.QtCore.pyqtSlot
     PyQt5.QtCore.Property = PyQt5.QtCore.pyqtProperty
+
+    from PyQt5 import uic
+    PyQt5.load_ui = uic.loadUi
 
     # Add
     PyQt5.__wrapper_version__ = __version__
@@ -51,6 +54,9 @@ def _pyqt4():
     PyQt4.QtCore.Slot = PyQt4.QtCore.pyqtSlot
     PyQt4.QtCore.Property = PyQt4.QtCore.pyqtProperty
 
+    from PyQt4 import uic
+    PyQt4.load_ui = uic.loadUi
+
     # Add
     PyQt4.__wrapper_version__ = __version__
     PyQt4.__binding__ = "PyQt4"
@@ -69,6 +75,15 @@ def _pyside2():
     PySide2.__binding_version__ = PySide2.__version__
     PySide2.__qt_version__ = PySide2.QtCore.qVersion()
 
+    # Remap
+    def load_ui(ui_filepath, *args, **kwargs):
+        """Wrap QtUiTools.QUiLoader().load()
+        for compatibility against PyQt5.uic.loadUi()
+        """
+        from PySide2 import QtUiTools
+        return QtUiTools.QUiLoader().load(ui_filepath)
+    PySide2.load_ui = load_ui
+
     return PySide2
 
 
@@ -80,6 +95,14 @@ def _pyside():
     PySide.QtWidgets = PySide.QtGui
 
     PySide.QtCore.QSortFilterProxyModel = PySide.QtGui.QSortFilterProxyModel
+
+    def load_ui(ui_filepath, *args, **kwargs):
+        """Wrap QtUiTools.QUiLoader().load()
+        for compatibility against PyQt5.uic.loadUi()
+        """
+        from PySide import QtUiTools
+        return QtUiTools.QUiLoader().load(ui_filepath)
+    PySide.load_ui = load_ui
 
     # Add
     PySide.__wrapper_version__ = __version__

--- a/Qt.py
+++ b/Qt.py
@@ -79,6 +79,9 @@ def _pyside2():
     def load_ui(ui_filepath, *args, **kwargs):
         """Wrap QtUiTools.QUiLoader().load()
         for compatibility against PyQt5.uic.loadUi()
+        
+        Args:
+            ui_filepath (str): The filepath to the .ui file
         """
         from PySide2 import QtUiTools
         return QtUiTools.QUiLoader().load(ui_filepath)
@@ -99,6 +102,9 @@ def _pyside():
     def load_ui(ui_filepath, *args, **kwargs):
         """Wrap QtUiTools.QUiLoader().load()
         for compatibility against PyQt5.uic.loadUi()
+        
+        Args:
+            ui_filepath (str): The filepath to the .ui file
         """
         from PySide import QtUiTools
         return QtUiTools.QUiLoader().load(ui_filepath)


### PR DESCRIPTION
Fix https://github.com/mottosso/Qt.py/issues/24

    from Qt import load_ui

- The `load_ui` function is made-up and doesn't exist directly under either PyQt or PySide.
- I was unable to "alias" `QtUiTools.QUiLoader().load` directly, which is why I had to create a function.

Example usage in [this gist](https://gist.github.com/fredrikaverpil/2bcd40900a44ae0a89dbc60980804fdf). You can run the code from the gist in a shell or in Maya. I'm adding Nuke support into the gist now too...

`Qt.load_ui` becomes really useful, actually. I initially thought this wouldn't be the case. I'm going to rewrite a lot of our in-house code to support this for easier maintainability between Maya, Nuke, standalone and PySide, PyQt4, PySide2, PyQt5. The Qt.py module has surpassed my expectations already! 😄 

Version bump to 0.2.4 included in this PR.

When this functionality is in Qt.py, I'll write a simple example to the README and link to the gist or possibly create a wiki entry. @mottosso would you prefer wiki or gist?