### PR TITLE
Provide Qt.load_ui (retry)

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -21,16 +21,19 @@ Usage:
 import os
 import sys
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 
 def _pyqt5():
     import PyQt5.Qt
+    from PyQt5 import uic
 
     # Remap
     PyQt5.QtCore.Signal = PyQt5.QtCore.pyqtSignal
     PyQt5.QtCore.Slot = PyQt5.QtCore.pyqtSlot
     PyQt5.QtCore.Property = PyQt5.QtCore.pyqtProperty
+
+    PyQt5.load_ui = uic.loadUi
 
     # Add
     PyQt5.__wrapper_version__ = __version__
@@ -43,6 +46,7 @@ def _pyqt5():
 
 def _pyqt4():
     import PyQt4.Qt
+    from PyQt4 import uic
 
     # Remap
     PyQt4.QtWidgets = PyQt4.QtGui
@@ -50,6 +54,8 @@ def _pyqt4():
     PyQt4.QtCore.Signal = PyQt4.QtCore.pyqtSignal
     PyQt4.QtCore.Slot = PyQt4.QtCore.pyqtSlot
     PyQt4.QtCore.Property = PyQt4.QtCore.pyqtProperty
+
+    PyQt4.load_ui = uic.loadUi
 
     # Add
     PyQt4.__wrapper_version__ = __version__
@@ -62,6 +68,7 @@ def _pyqt4():
 
 def _pyside2():
     import PySide2
+    from PySide2 import QtUiTools
 
     # Add
     PySide2.__wrapper_version__ = __version__
@@ -69,17 +76,39 @@ def _pyside2():
     PySide2.__binding_version__ = PySide2.__version__
     PySide2.__qt_version__ = PySide2.QtCore.qVersion()
 
+    # Remap
+    def load_ui(ui_filepath, *args, **kwargs):
+        """Wrap QtUiTools.QUiLoader().load()
+        for compatibility against PyQt5.uic.loadUi()
+
+        Args:
+            ui_filepath (str): The filepath to the .ui file
+        """
+        return QtUiTools.QUiLoader().load(ui_filepath)
+    PySide2.load_ui = load_ui
+
     return PySide2
 
 
 def _pyside():
     import PySide
     import PySide.QtGui
+    from PySide import QtUiTools
 
     # Remap
     PySide.QtWidgets = PySide.QtGui
 
     PySide.QtCore.QSortFilterProxyModel = PySide.QtGui.QSortFilterProxyModel
+
+    def load_ui(ui_filepath, *args, **kwargs):
+        """Wrap QtUiTools.QUiLoader().load()
+        for compatibility against PyQt4.uic.loadUi()
+
+        Args:
+            ui_filepath (str): The filepath to the .ui file
+        """
+        return QtUiTools.QUiLoader().load(ui_filepath)
+    PySide.load_ui = load_ui
 
     # Add
     PySide.__wrapper_version__ = __version__
@@ -104,7 +133,7 @@ def _init():
     preferred = os.getenv("QT_PREFERRED_BINDING")
 
     if preferred:
-        
+
         # Debug mode, used in installer
         if preferred == "None":
             sys.modules[__name__].__wrapper_version__ = __version__

--- a/README.md
+++ b/README.md
@@ -111,6 +111,30 @@ $ python -c "import Qt;print(Qt.__binding__)"
 PyQt5
 ```
 
+**Load Qt Designer .ui files**
+
+The `uic.loadUi` function of PyQt4 and PyQt5 as well as the `QtUiTools.QUiLoader().load` function of PySide/PySide2 are mappend to a convenience function `load_ui`.
+
+```python
+import sys
+from Qt import QtWidgets
+from Qt import load_ui
+
+
+class Hello(QtWidgets.QWidget):
+    def __init__(self):
+        super(Hello, self).__init__()
+        self.ui = load_ui('my_ui.ui')
+
+app = QtWidgets.QApplication(sys.argv)
+window = Hello()
+window.ui.show()
+sys.exit(app.exec_())
+```
+
+Please note, for maximum compatibility, only pass the argument of the filename to the `load_ui` function.
+
+
 <br>
 <br>
 <br>


### PR DESCRIPTION
Fix https://github.com/mottosso/Qt.py/issues/24

    from Qt import load_ui

- The `load_ui` function is made-up and doesn't exist directly under either PyQt or PySide.
- I was unable to "alias" `QtUiTools.QUiLoader().load` directly, which is why I had to create a function.

Example usage in [this gist](https://gist.github.com/fredrikaverpil/2bcd40900a44ae0a89dbc60980804fdf). You can run the code from the gist in a shell or in Maya. I'm adding Nuke support too.

`Qt.load_ui` becomes really useful, actually. I initially thought this wouldn't be the case. I'm going to rewrite a lot of our in-house code to support this for easier maintainability between Maya, Nuke, standalone and PySide, PyQt4, PySide2, PyQt5. The Qt.py module has surpassed my expectations already! 😄 

Version bump to 0.2.5 included in this PR.

When this functionality is in Qt.py, I'll write a simple example to the README and link to the gist or possibly create a wiki entry. @mottosso would you prefer wiki or gist?

### Discussion
I'm defining the same `load_ui()` function twice. It feels like it could reside in a place where we put such global functions rather than placing it inside each "load function".

- Function placement (global vs local to the loading function)
- How should such global functions be named?
  - Prefixed?
    - `_load_ui`
    - `___load_ui`
    - `_pyside_load_ui`
    - `__pyside_load_ui`