### PR TITLE
Added link to pyvfx-boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,4 @@ None yet.
 Send us a pull-request with your project here.
 
 - https://github.com/pyblish/pyblish-lite
+- https://github.com/fredrikaverpil/pyvfx-boilerplate


### PR DESCRIPTION
I've created an example/boilerplate script which loads .ui files into a window. Figured it could be nice to link to it, as it relies on `Qt.py`.

You can run it in a number of ways, as can be seen in the [README](https://github.com/fredrikaverpil/pyvfx-boilerplate/blob/master/README.md).