### PR TITLE
sip API v2

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -53,12 +53,12 @@ def _pyqt4():
         sip.setapi("QTextStream", 2)
         sip.setapi("QTime", 2)
         sip.setapi("QUrl", 2)
-    except AttributeError as error:
-        raise ImportError(error)
+    except AttributeError:
+        raise ImportError
         # PyQt4 < v4.6
-    except ValueError as error:
+    except ValueError:
         # API version already set to v1
-        raise ImportError(error)
+        raise ImportError
 
     import PyQt4.Qt
 

--- a/Qt.py
+++ b/Qt.py
@@ -46,6 +46,7 @@ def _pyqt5():
 def _pyqt4():
     import PyQt4.Qt
     from PyQt4 import uic
+    import sip
 
     # Remap
     PyQt4.QtWidgets = PyQt4.QtGui
@@ -59,7 +60,7 @@ def _pyqt4():
     PyQt4.__binding_version__ = PyQt4.QtCore.PYQT_VERSION_STR
     PyQt4.__qt_version__ = PyQt4.QtCore.PYQT_VERSION_STR
     PyQt4.load_ui = install_load_ui(module=uic)
-    set_sip_api_v2()
+    set_sip_api_v2(module=sip)
 
     return PyQt4
 
@@ -97,8 +98,13 @@ def _pyside():
     return PySide
 
 
-def set_sip_api_v2():
-    """Attempt to set sip API to v2"""
+def set_sip_api_v2(module):
+    """Attempt to set sip API to v2
+
+        Args:
+            module (module): The sip module
+
+    """
 
     def setapi(name, version):
         """Set the given API `version` to the object `name`.
@@ -117,10 +123,8 @@ def set_sip_api_v2():
         except ValueError as error:
             sys.stdout.write('Qt Warning: ' + str(error) + '\n')    
 
-    import sip
     setapi(name='QString', version=2)
     setapi(name='QVariant', version=2)
-
 
 
 def install_load_ui(module):

--- a/Qt.py
+++ b/Qt.py
@@ -59,6 +59,7 @@ def _pyqt4():
     PyQt4.__binding_version__ = PyQt4.QtCore.PYQT_VERSION_STR
     PyQt4.__qt_version__ = PyQt4.QtCore.PYQT_VERSION_STR
     PyQt4.load_ui = install_load_ui(module=uic)
+    set_sip_api_v2()
 
     return PyQt4
 
@@ -94,6 +95,32 @@ def _pyside():
     PySide.load_ui = install_load_ui(module=QtUiTools)
 
     return PySide
+
+
+def set_sip_api_v2():
+    """Attempt to set sip API to v2"""
+
+    def setapi(name, version):
+        """Set the given API `version` to the object `name`.
+
+        If the function fails because the API had already been set to
+        e.g. version 1, it will grab the ValueError and print it.
+
+        Args:
+            name (str): The name of the class to set
+            version (int): The version of the API to set
+
+        """
+
+        try:
+            sip.setapi(name, version)
+        except ValueError as error:
+            sys.stdout.write('Qt Warning: ' + str(error) + '\n')    
+
+    import sip
+    setapi(name='QString', version=2)
+    setapi(name='QVariant', version=2)
+
 
 
 def install_load_ui(module):

--- a/Qt.py
+++ b/Qt.py
@@ -69,15 +69,14 @@ def _pyqt4():
             sip.setapi('QTextStream', 2)
             sip.setapi('QTime', 2)
             sip.setapi('QUrl', 2)
-            PyQt4.__sip_api_version__ = 2
         except AttributeError as error:
             # PyQt < v4.6
-            PyQt4.__sip_api_version__ = sip.getapi('QString')
+            sys.stdout.write('Qt.py Warning: ' + str(error) + '\n')
         except ValueError as error:
-            # Version 1 already set
-            PyQt4.__sip_api_version__ = sip.getapi('QString')
+            # Version (1?) already set
+            sys.stdout.write('Qt.py Warning: ' + str(error) + '\n')
     except ImportError as error:
-        sys.stdout.write('Qt Warning: ' + str(error) + '\n')
+        sys.stdout.write('Qt.py Warning: ' + str(error) + '\n')
 
     return PyQt4
 

--- a/Qt.py
+++ b/Qt.py
@@ -53,11 +53,12 @@ def _pyqt4():
         sip.setapi("QTextStream", 2)
         sip.setapi("QTime", 2)
         sip.setapi("QUrl", 2)
-    except AttributeError:
-        raise AttributeError("Qt.py error: PyQt version < 4.6 not supported")
+    except AttributeError as error:
+        raise ImportError(error)
+        # PyQt4 < v4.6
     except ValueError as error:
         # API version already set to v1
-        raise ValueError("Qt.py error: " + str(error))
+        raise ImportError(error)
 
     import PyQt4.Qt
 

--- a/Qt.py
+++ b/Qt.py
@@ -21,7 +21,7 @@ Usage:
 import os
 import sys
 
-__version__ = "0.2.7"
+__version__ = "0.3.0"
 
 
 def _pyqt5():

--- a/Qt.py
+++ b/Qt.py
@@ -21,7 +21,7 @@ Usage:
 import os
 import sys
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
 
 def _pyqt5():
@@ -44,24 +44,20 @@ def _pyqt5():
 
 def _pyqt4():
     # Attempt to set sip API v2 (must be done prior to importing PyQt4)
+    import sip
     try:
-        import sip
-        try:
-            sip.setapi('QString', 2)
-            sip.setapi('QVariant', 2)
-            sip.setapi('QDate', 2)
-            sip.setapi('QDateTime', 2)
-            sip.setapi('QTextStream', 2)
-            sip.setapi('QTime', 2)
-            sip.setapi('QUrl', 2)
-        except AttributeError as error:
-            # PyQt < v4.6
-            sys.stdout.write('Qt.py Warning: ' + str(error) + '\n')
-        except ValueError as error:
-            # Version (1?) already set
-            sys.stdout.write('Qt.py Warning: ' + str(error) + '\n')
-    except ImportError as error:
-        sys.stdout.write('Qt.py Warning: ' + str(error) + '\n')
+        sip.setapi("QString", 2)
+        sip.setapi("QVariant", 2)
+        sip.setapi("QDate", 2)
+        sip.setapi("QDateTime", 2)
+        sip.setapi("QTextStream", 2)
+        sip.setapi("QTime", 2)
+        sip.setapi("QUrl", 2)
+    except AttributeError:
+        raise AttributeError("Qt.py error: PyQt version < 4.6 not supported")
+    except ValueError as error:
+        # API version already set to v1
+        raise ValueError("Qt.py error: " + str(error))
 
     import PyQt4.Qt
 

--- a/Qt.py
+++ b/Qt.py
@@ -60,7 +60,7 @@ def _pyqt4():
     PyQt4.__binding_version__ = PyQt4.QtCore.PYQT_VERSION_STR
     PyQt4.__qt_version__ = PyQt4.QtCore.PYQT_VERSION_STR
     PyQt4.load_ui = install_load_ui(module=uic)
-    set_sip_api_v2(module=sip)
+    set_sip_api_v2(sip_module=sip)
 
     return PyQt4
 
@@ -98,11 +98,11 @@ def _pyside():
     return PySide
 
 
-def set_sip_api_v2(module):
-    """Attempt to set sip API to v2
+def set_sip_api_v2(sip_module):
+    """Attempt to set sip API to v2.
 
         Args:
-            module (module): The sip module
+            sip_module (module): The sip module
 
     """
 
@@ -123,6 +123,7 @@ def set_sip_api_v2(module):
         except ValueError as error:
             sys.stdout.write('Qt Warning: ' + str(error) + '\n')    
 
+    sip = sip_module
     setapi(name='QString', version=2)
     setapi(name='QVariant', version=2)
 

--- a/Qt.py
+++ b/Qt.py
@@ -58,6 +58,27 @@ def _pyqt4():
     PyQt4.__qt_version__ = PyQt4.QtCore.QT_VERSION_STR
     PyQt4.load_ui = pyqt4_load_ui
 
+    # Attempt to set sip API v2
+    try:
+        import sip
+        try:
+            sip.setapi('QString', 2)
+            sip.setapi('QVariant', 2)
+            sip.setapi('QDate', 2)
+            sip.setapi('QDateTime', 2)
+            sip.setapi('QTextStream', 2)
+            sip.setapi('QTime', 2)
+            sip.setapi('QUrl', 2)
+            PyQt4.__sip_api_version__ = 2
+        except AttributeError as error:
+            # PyQt < v4.6
+            PyQt4.__sip_api_version__ = sip.getapi('QString')
+        except ValueError as error:
+            # Version 1 already set
+            PyQt4.__sip_api_version__ = sip.getapi('QString')
+    except ImportError as error:
+        sys.stdout.write('Qt Warning: ' + str(error) + '\n')
+
     return PyQt4
 
 

--- a/Qt.py
+++ b/Qt.py
@@ -43,22 +43,7 @@ def _pyqt5():
 
 
 def _pyqt4():
-    import PyQt4.Qt
-
-    # Remap
-    PyQt4.QtWidgets = PyQt4.QtGui
-    PyQt4.QtCore.Signal = PyQt4.QtCore.pyqtSignal
-    PyQt4.QtCore.Slot = PyQt4.QtCore.pyqtSlot
-    PyQt4.QtCore.Property = PyQt4.QtCore.pyqtProperty
-
-    # Add
-    PyQt4.__wrapper_version__ = __version__
-    PyQt4.__binding__ = "PyQt4"
-    PyQt4.__binding_version__ = PyQt4.QtCore.PYQT_VERSION_STR
-    PyQt4.__qt_version__ = PyQt4.QtCore.QT_VERSION_STR
-    PyQt4.load_ui = pyqt4_load_ui
-
-    # Attempt to set sip API v2
+    # Attempt to set sip API v2 (must be done prior to importing PyQt4)
     try:
         import sip
         try:
@@ -77,6 +62,21 @@ def _pyqt4():
             sys.stdout.write('Qt.py Warning: ' + str(error) + '\n')
     except ImportError as error:
         sys.stdout.write('Qt.py Warning: ' + str(error) + '\n')
+
+    import PyQt4.Qt
+
+    # Remap
+    PyQt4.QtWidgets = PyQt4.QtGui
+    PyQt4.QtCore.Signal = PyQt4.QtCore.pyqtSignal
+    PyQt4.QtCore.Slot = PyQt4.QtCore.pyqtSlot
+    PyQt4.QtCore.Property = PyQt4.QtCore.pyqtProperty
+
+    # Add
+    PyQt4.__wrapper_version__ = __version__
+    PyQt4.__binding__ = "PyQt4"
+    PyQt4.__binding_version__ = PyQt4.QtCore.PYQT_VERSION_STR
+    PyQt4.__qt_version__ = PyQt4.QtCore.QT_VERSION_STR
+    PyQt4.load_ui = pyqt4_load_ui
 
     return PyQt4
 

--- a/Qt.py
+++ b/Qt.py
@@ -60,7 +60,12 @@ def _pyqt4():
     PyQt4.__binding_version__ = PyQt4.QtCore.PYQT_VERSION_STR
     PyQt4.__qt_version__ = PyQt4.QtCore.PYQT_VERSION_STR
     PyQt4.load_ui = install_load_ui(module=uic)
-    set_sip_api_v2(sip_module=sip)
+
+    try:
+        sip.setapi('QString', 2)
+        sip.setapi('QVariant', 2)
+    except ValueError as error:
+        sys.stdout.write('Qt Warning: ' + str(error) + '\n')
 
     return PyQt4
 
@@ -96,36 +101,6 @@ def _pyside():
     PySide.load_ui = install_load_ui(module=QtUiTools)
 
     return PySide
-
-
-def set_sip_api_v2(sip_module):
-    """Attempt to set sip API to v2.
-
-        Args:
-            sip_module (module): The sip module
-
-    """
-
-    def setapi(name, version):
-        """Set the given API `version` to the object `name`.
-
-        If the function fails because the API had already been set to
-        e.g. version 1, it will grab the ValueError and print it.
-
-        Args:
-            name (str): The name of the class to set
-            version (int): The version of the API to set
-
-        """
-
-        try:
-            sip.setapi(name, version)
-        except ValueError as error:
-            sys.stdout.write('Qt Warning: ' + str(error) + '\n')    
-
-    sip = sip_module
-    setapi(name='QString', version=2)
-    setapi(name='QVariant', version=2)
 
 
 def install_load_ui(module):

--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ Please note, for maximum compatibility, only pass the argument of the filename t
 If you're using PyQt4, `sip` attempts to set its API to version 2 for the following:
 - `QString`
 - `QVariant`
+- `QDate`
+- `QDateTime`
+- `QTextStream`
+- `QTime`
+- `QUrl`
 
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ sys.exit(app.exec_())
 
 Please note, for maximum compatibility, only pass the argument of the filename to the `load_ui` function.
 
+**sip API v2**
+
+If you're using PyQt4, `sip` attempts to set its API to version 2 for the following:
+- `QString`
+- `QVariant`
 
 <br>
 <br>

--- a/tests.py
+++ b/tests.py
@@ -77,7 +77,7 @@ def test_preferred_none():
 
 @with_setup(clean)
 def test_coexistence():
-    """Qt.py may be use alongside the actual binding"""
+    """Qt.py may be use alongside the actudddddddddddddal binding"""
 
     with pyside():
         from Qt import QtCore
@@ -94,9 +94,9 @@ def test_coexistence():
 def test_sip_api_qtpy():
     """Qt.py with preferred binding PyQt4 should have sip version 2"""
 
-    os.environ["QT_PREFERRED_BINDING"] = "PyQt4"
-    import Qt
-    import sip
-    api_version = sip.getapi("QString")
-    assert api_version == 2, ("PyQt4 API version should be 2, "
-                              "instead is %s" % api_version)
+    with pyqt4():
+        import Qt
+        import sip
+        assert sip.getapi("QString") == 2, ("PyQt4 API version should be 2, "
+                                            "instead is %s"
+                                            % sip.getapi("QString"))

--- a/tests.py
+++ b/tests.py
@@ -15,6 +15,7 @@ from nose.tools import (
     assert_raises,
 )
 
+
 @contextlib.contextmanager
 def pyqt4():
     os.environ["QT_PREFERRED_BINDING"] = "PyQt4"
@@ -57,7 +58,7 @@ def test_preferred():
 
     # Try again
     sys.modules.pop("Qt")
-    
+
     with pyside():
         import Qt
         assert Qt.__name__ == "PySide", ("PySide should have been picked, "
@@ -76,7 +77,7 @@ def test_preferred_none():
 @with_setup(clean)
 def test_coexistence():
     """Qt.py may be use alongside the actual binding"""
-    
+
     with pyside():
         from Qt import QtCore
         import PySide.QtGui
@@ -86,3 +87,26 @@ def test_coexistence():
 
         # But does not delete the original
         assert PySide.QtGui.QStringListModel
+
+
+@with_setup(clean)
+def test_sip_api_pyqt4():
+    """PyQt should have sip version 1"""
+
+    from PyQt4 import QtCore
+    import sip
+    api_version = sip.getapi('QString')
+    assert api_version == 1, ("PyQt4 API version should be 1, "
+                              "instead is %s" % api_version)
+
+
+@with_setup(clean)
+def test_sip_api_qtpy():
+    """Qt.py with preferred binding PyQt4 should have sip version 2"""
+
+    os.environ["QT_PREFERRED_BINDING"] = "PyQt4"
+    import Qt
+    import sip
+    api_version = sip.getapi('QString')
+    assert api_version == 2, ("PyQt4 API version should be 2, "
+                              "instead is %s" % api_version)

--- a/tests.py
+++ b/tests.py
@@ -95,7 +95,7 @@ def test_sip_api_pyqt4():
 
     from PyQt4 import QtCore
     import sip
-    api_version = sip.getapi('QString')
+    api_version = sip.getapi("QString")
     assert api_version == 1, ("PyQt4 API version should be 1, "
                               "instead is %s" % api_version)
 
@@ -104,9 +104,10 @@ def test_sip_api_pyqt4():
 def test_sip_api_qtpy():
     """Qt.py with preferred binding PyQt4 should have sip version 2"""
 
+    sys.modules.pop("sip")
     os.environ["QT_PREFERRED_BINDING"] = "PyQt4"
     import Qt
     import sip
-    api_version = sip.getapi('QString')
+    api_version = sip.getapi("QString")
     assert api_version == 2, ("PyQt4 API version should be 2, "
                               "instead is %s" % api_version)

--- a/tests.py
+++ b/tests.py
@@ -105,8 +105,14 @@ def test_sip_api_pyqt4():
 def test_sip_api_qtpy():
     """Qt.py with preferred binding PyQt4 should have sip version 2"""
 
-    sys.modules.pop("PyQt4")
-    sys.modules.pop("sip")
+    def pop_module(mod):
+        """Remove given module from sys.modules"""
+        if mod in sys.modules:
+            sys.modules.pop(mod)
+
+    pop_module("Qt")
+    pop_module("PyQt4")
+    pop_module("sip")
     os.environ["QT_PREFERRED_BINDING"] = "PyQt4"
     import Qt
     import sip

--- a/tests.py
+++ b/tests.py
@@ -77,7 +77,7 @@ def test_preferred_none():
 
 @with_setup(clean)
 def test_coexistence():
-    """Qt.py may be use alongside the actudddddddddddddal binding"""
+    """Qt.py may be use alongside the actual binding"""
 
     with pyside():
         from Qt import QtCore

--- a/tests.py
+++ b/tests.py
@@ -110,7 +110,6 @@ def test_sip_api_qtpy():
         if mod in sys.modules:
             sys.modules.pop(mod)
 
-    pop_module("Qt")
     pop_module("PyQt4")
     pop_module("sip")
     os.environ["QT_PREFERRED_BINDING"] = "PyQt4"

--- a/tests.py
+++ b/tests.py
@@ -91,27 +91,9 @@ def test_coexistence():
 
 
 @with_setup(clean)
-def test_sip_api_pyqt4():
-    """PyQt should have sip version 1"""
-
-    from PyQt4 import QtCore
-    import sip
-    api_version = sip.getapi("QString")
-    assert api_version == 1, ("PyQt4 API version should be 1, "
-                              "instead is %s" % api_version)
-
-
-@with_setup(clean)
 def test_sip_api_qtpy():
     """Qt.py with preferred binding PyQt4 should have sip version 2"""
 
-    def pop_module(mod):
-        """Remove given module from sys.modules"""
-        if mod in sys.modules:
-            sys.modules.pop(mod)
-
-    pop_module("PyQt4")
-    pop_module("sip")
     os.environ["QT_PREFERRED_BINDING"] = "PyQt4"
     import Qt
     import sip

--- a/tests.py
+++ b/tests.py
@@ -34,6 +34,7 @@ def clean():
     """Provide clean working environment"""
     sys.modules.pop("Qt", None)
     os.environ.pop("QT_PREFERRED_BINDING", None)
+    sys.modules.pop("sip", None)
 
 
 def test_environment():
@@ -104,6 +105,7 @@ def test_sip_api_pyqt4():
 def test_sip_api_qtpy():
     """Qt.py with preferred binding PyQt4 should have sip version 2"""
 
+    sys.modules.pop("PyQt4")
     sys.modules.pop("sip")
     os.environ["QT_PREFERRED_BINDING"] = "PyQt4"
     import Qt


### PR DESCRIPTION
Fix #37

@justinfx @mottosso Let's discuss this.

I get this when the API was already set to v2:

```python
python
>>> import Qt
Qt Warning: API 'QString' has already been set to version 1
Qt Warning: API 'QVariant' has already been set to version 1
```