### PR TITLE
Implement nosepipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 dist: trusty
 
 python:
+  - 2.6
   - 2.7
   - 3.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   # Based on http://stackoverflow.com/a/24545890/478949
   - sudo apt-get install -y qt4-qmake libqt4-dev
   - sudo apt-get install -y python-qt4 python-pyside
-  - sudo apt-get install -y python3-pyqt4 python3-pyside
+  - sudo apt-get install -y python3-pyqt4 python3-pyside python3-pip
   - sudo pip install nosepipe
   - sudo pip3 install nosepipe
   - python -c "import PySide;print(PySide)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - sudo apt-get install -y python-qt4 python-pyside
   - sudo apt-get install -y python3-pyqt4 python3-pyside
   - sudo pip install nosepipe
+  - sudo pip3 install nosepipe
   - python -c "import PySide;print(PySide)"
   - python -c "import PyQt4;print(PyQt4)"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 dist: trusty
 
 python:
-  - 2.6
   - 2.7
   - 3.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,18 +36,13 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script:
-<<<<<<< develop
-  - nosetests --verbose
+  - nosetests --verbose --with-process-isolation
 
   # Test setup.py
   - pip install file://$(pwd)
 
   # Test Dockerfile
   - docker build -t mottosso/qt.py .
-=======
-  - nosetests --verbose --with-process-isolation
-  - pip install git+git://github.com/mottosso/Qt.py.git
->>>>>>> Remove filepath, add pip install nosepipe
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - sudo apt-get install -y qt4-qmake libqt4-dev
   - sudo apt-get install -y python-qt4 python-pyside
   - sudo apt-get install -y python3-pyqt4 python3-pyside
+  - sudo pip install nosepipe
   - python -c "import PySide;print(PySide)"
   - python -c "import PyQt4;print(PyQt4)"
 
@@ -34,6 +35,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script:
+<<<<<<< develop
   - nosetests --verbose
 
   # Test setup.py
@@ -41,6 +43,10 @@ script:
 
   # Test Dockerfile
   - docker build -t mottosso/qt.py .
+=======
+  - nosetests --verbose --with-process-isolation
+  - pip install git+git://github.com/mottosso/Qt.py.git
+>>>>>>> Remove filepath, add pip install nosepipe
 
 deploy:
   provider: pypi

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,11 @@ RUN apt-get update && apt-get install -y \
     python-qt4 \
     python-pyside \
     python-pip
-<<<<<<< develop
 
 # Nose is the Python test-runner
-RUN pip install nose
+RUN pip install nose nosepipe
 
 # Enable additional output from Qt.py
 ENV QT_VERBOSE true
 
-ENTRYPOINT nosetests --verbose /Qt.py/tests.py
-=======
-RUN pip install nose nosepipe
 ENTRYPOINT nosetests --verbose --with-process-isolation /Qt.py/tests.py
->>>>>>> Implement nosepipe

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y \
     python-qt4 \
     python-pyside \
     python-pip
+<<<<<<< develop
 
 # Nose is the Python test-runner
 RUN pip install nose
@@ -12,3 +13,7 @@ RUN pip install nose
 ENV QT_VERBOSE true
 
 ENTRYPOINT nosetests --verbose /Qt.py/tests.py
+=======
+RUN pip install nose nosepipe
+ENTRYPOINT nosetests --verbose --with-process-isolation /Qt.py/tests.py
+>>>>>>> Implement nosepipe

--- a/tests.py
+++ b/tests.py
@@ -80,6 +80,16 @@ def test_coexistence():
         assert PySide.QtGui.QStringListModel
 
 
+def test_sip_api_pyqt4():
+    """PyQt4 should have sip version 1"""
+
+    from PyQt4 import QtCore
+    import sip
+    assert sip.getapi("QString") == 1, ("PyQt4 API version should be 1, "
+                                        "instead is %s"
+                                        % sip.getapi("QString"))
+
+
 def test_sip_api_qtpy():
     """Qt.py with preferred binding PyQt4 should have sip version 2"""
 
@@ -89,13 +99,3 @@ def test_sip_api_qtpy():
         assert sip.getapi("QString") == 2, ("PyQt4 API version should be 2, "
                                             "instead is %s"
                                             % sip.getapi("QString"))
-
-
-def test_sip_api_pyqt4():
-    """PyQt4 should have sip version 1"""
-
-    from PyQt4 import QtCore
-    import sip
-    assert sip.getapi("QString") == 1, ("PyQt4 API version should be 1, "
-                                        "instead is %s"
-                                        % sip.getapi("QString"))

--- a/tests.py
+++ b/tests.py
@@ -81,7 +81,7 @@ def test_coexistence():
 
 
 def test_sip_api_pyqt4():
-    """PyQt4 default sip API version"""
+    """PyQt4 default sip API version (Python 2.x = 1, Python 3.x = 2)"""
 
     from PyQt4 import QtCore
     import sip
@@ -107,7 +107,8 @@ def test_sip_api_qtpy():
                                             % sip.getapi("QString"))
 
 def test_sip_api_already_set():
-    """Qt.py should cause ImportError when sip API v1 was already set"""
+    """Qt.py should cause ImportError when sip API v1 was already set
+    (Python 2.x only)"""
 
     with pyqt4():
         def import_qt():

--- a/tests.py
+++ b/tests.py
@@ -10,12 +10,11 @@ import sys
 import imp
 import contextlib
 
+from nose import SkipTest
 from nose.tools import (
     with_setup,
     assert_raises,
 )
-
-from nose.plugins.skip import SkipTest
 
 
 @contextlib.contextmanager
@@ -125,4 +124,4 @@ def test_sip_api_already_set():
             sip.setapi("QString", 1)
             assert_raises(ImportError, import_qt)
     else:
-        raise SkipTest("Test skipped when Python version not equal to 2.x")
+        raise SkipTest("Skipped because Python version is not 2.x")

--- a/tests.py
+++ b/tests.py
@@ -89,13 +89,3 @@ def test_sip_api_qtpy():
         assert sip.getapi("QString") == 2, ("PyQt4 API version should be 2, "
                                             "instead is %s"
                                             % sip.getapi("QString"))
-
-
-def test_sip_api_pyqt4():
-    """PyQt4 should have sip version 1"""
-
-    from PyQt4 import QtCore
-    import sip
-    assert sip.getapi("QString") == 1, ("PyQt4 API version should be 1, "
-                                        "instead is %s"
-                                        % sip.getapi("QString"))

--- a/tests.py
+++ b/tests.py
@@ -30,13 +30,6 @@ def pyside():
     os.environ.pop("QT_PREFERRED_BINDING")
 
 
-def clean():
-    """Provide clean working environment"""
-    sys.modules.pop("Qt", None)
-    os.environ.pop("QT_PREFERRED_BINDING", None)
-    sys.modules.pop("sip", None)
-
-
 def test_environment():
     """Tests require PySide and PyQt4 bindings to be installed"""
 
@@ -48,7 +41,6 @@ def test_environment():
     assert_raises(ImportError, imp.find_module, "PyQt5")
 
 
-@with_setup(clean)
 def test_preferred():
     """Setting QT_PREFERRED_BINDING properly forces a particular binding"""
     import Qt
@@ -66,7 +58,6 @@ def test_preferred():
                                          "instead got %s" % Qt)
 
 
-@with_setup(clean)
 def test_preferred_none():
     """Preferring None shouldn't import anything"""
 
@@ -75,7 +66,6 @@ def test_preferred_none():
     assert Qt.__name__ == "Qt", Qt
 
 
-@with_setup(clean)
 def test_coexistence():
     """Qt.py may be use alongside the actual binding"""
 
@@ -90,7 +80,6 @@ def test_coexistence():
         assert PySide.QtGui.QStringListModel
 
 
-@with_setup(clean)
 def test_sip_api_qtpy():
     """Qt.py with preferred binding PyQt4 should have sip version 2"""
 
@@ -100,3 +89,13 @@ def test_sip_api_qtpy():
         assert sip.getapi("QString") == 2, ("PyQt4 API version should be 2, "
                                             "instead is %s"
                                             % sip.getapi("QString"))
+
+
+def test_sip_api_pyqt4():
+    """PyQt4 should have sip version 1"""
+
+    from PyQt4 import QtCore
+    import sip
+    assert sip.getapi("QString") == 1, ("PyQt4 API version should be 1, "
+                                        "instead is %s"
+                                        % sip.getapi("QString"))

--- a/tests.py
+++ b/tests.py
@@ -16,7 +16,7 @@ from nose.tools import (
     assert_raises,
 )
 
-PYTHON_VERSION = sys.version_info[0]  # e.g. 2 or 3
+PY_VER_MAJOR = sys.version_info[0]  # e.g. 2 or 3
 
 
 @contextlib.contextmanager
@@ -88,12 +88,12 @@ def test_sip_api_pyqt4():
 
     from PyQt4 import QtCore
     import sip
-    if sys.version_info[0] == 2:
+    if PY_VER_MAJOR == 2:
         # Python 2.x
         assert sip.getapi("QString") == 1, ("PyQt4 API version should be 1, "
                                             "instead is %s"
                                             % sip.getapi("QString"))
-    elif sys.version_info[0] == 3:
+    elif PY_VER_MAJOR == 3:
         # Python 3.x
         assert sip.getapi("QString") == 2, ("PyQt4 API version should be 2, "
                                             "instead is %s"
@@ -110,7 +110,7 @@ def test_sip_api_qtpy():
                                             "instead is %s"
                                             % sip.getapi("QString"))
 
-if PYTHON_VERSION == 2:
+if PY_VER_MAJOR == 2:
     def test_sip_api_already_set():
         """Qt.py should cause ImportError when sip API v1 was already set
         (Python 2.x only)"""

--- a/tests.py
+++ b/tests.py
@@ -113,10 +113,10 @@ def test_sip_api_already_set():
         def import_qt():
             import Qt
 
-    if sys.version_info[0] == 2:
-        # Python 2.x
+        if sys.version_info[0] == 2:
+            # Python 2.x
 
-        from PyQt4 import QtCore
-        import sip
-        sip.setapi("QString", 1)
-        assert_raises(ImportError, import_qt)
+            from PyQt4 import QtCore
+            import sip
+            sip.setapi("QString", 1)
+            assert_raises(ImportError, import_qt)

--- a/tests.py
+++ b/tests.py
@@ -81,14 +81,20 @@ def test_coexistence():
 
 
 def test_sip_api_pyqt4():
-    """PyQt4 should have sip version 1"""
+    """PyQt4 default sip API version"""
 
     from PyQt4 import QtCore
     import sip
-    assert sip.getapi("QString") == 1, ("PyQt4 API version should be 1, "
-                                        "instead is %s"
-                                        % sip.getapi("QString"))
-
+    if sys.version_info[0] == 2:
+        # Python 2.x
+        assert sip.getapi("QString") == 1, ("PyQt4 API version should be 1, "
+                                            "instead is %s"
+                                            % sip.getapi("QString"))
+    elif sys.version_info[0] == 3:
+        # Python 3.x
+        assert sip.getapi("QString") == 2, ("PyQt4 API version should be 2, "
+                                            "instead is %s"
+                                            % sip.getapi("QString"))
 
 def test_sip_api_qtpy():
     """Qt.py with preferred binding PyQt4 should have sip version 2"""

--- a/tests.py
+++ b/tests.py
@@ -15,6 +15,8 @@ from nose.tools import (
     assert_raises,
 )
 
+from nose.plugins.skip import SkipTest
+
 
 @contextlib.contextmanager
 def pyqt4():
@@ -96,6 +98,7 @@ def test_sip_api_pyqt4():
                                             "instead is %s"
                                             % sip.getapi("QString"))
 
+
 def test_sip_api_qtpy():
     """Qt.py with preferred binding PyQt4 should have sip version 2"""
 
@@ -106,18 +109,20 @@ def test_sip_api_qtpy():
                                             "instead is %s"
                                             % sip.getapi("QString"))
 
+
 def test_sip_api_already_set():
     """Qt.py should cause ImportError when sip API v1 was already set
     (Python 2.x only)"""
 
-    with pyqt4():
-        def import_qt():
-            import Qt
-
-        if sys.version_info[0] == 2:
-            # Python 2.x
+    if sys.version_info[0] == 2:
+        # Python 2.x
+        with pyqt4():
+            def import_qt():
+                import Qt
 
             from PyQt4 import QtCore
             import sip
             sip.setapi("QString", 1)
             assert_raises(ImportError, import_qt)
+    else:
+        raise SkipTest("Test skipped when Python version ≠ 2.x")

--- a/tests.py
+++ b/tests.py
@@ -89,3 +89,13 @@ def test_sip_api_qtpy():
         assert sip.getapi("QString") == 2, ("PyQt4 API version should be 2, "
                                             "instead is %s"
                                             % sip.getapi("QString"))
+
+
+def test_sip_api_pyqt4():
+    """PyQt4 should have sip version 1"""
+
+    from PyQt4 import QtCore
+    import sip
+    assert sip.getapi("QString") == 1, ("PyQt4 API version should be 1, "
+                                        "instead is %s"
+                                        % sip.getapi("QString"))

--- a/tests.py
+++ b/tests.py
@@ -113,6 +113,9 @@ def test_sip_api_already_set():
         def import_qt():
             import Qt
 
+    if sys.version_info[0] == 2:
+        # Python 2.x
+
         from PyQt4 import QtCore
         import sip
         sip.setapi("QString", 1)

--- a/tests.py
+++ b/tests.py
@@ -16,6 +16,8 @@ from nose.tools import (
     assert_raises,
 )
 
+PYTHON_VERSION = sys.version_info[0]  # e.g. 2 or 3
+
 
 @contextlib.contextmanager
 def pyqt4():
@@ -108,13 +110,11 @@ def test_sip_api_qtpy():
                                             "instead is %s"
                                             % sip.getapi("QString"))
 
+if PYTHON_VERSION == 2:
+    def test_sip_api_already_set():
+        """Qt.py should cause ImportError when sip API v1 was already set
+        (Python 2.x only)"""
 
-def test_sip_api_already_set():
-    """Qt.py should cause ImportError when sip API v1 was already set
-    (Python 2.x only)"""
-
-    if sys.version_info[0] == 2:
-        # Python 2.x
         with pyqt4():
             def import_qt():
                 import Qt
@@ -123,5 +123,3 @@ def test_sip_api_already_set():
             import sip
             sip.setapi("QString", 1)
             assert_raises(ImportError, import_qt)
-    else:
-        raise SkipTest("Skipped because Python version is not 2.x")

--- a/tests.py
+++ b/tests.py
@@ -99,3 +99,15 @@ def test_sip_api_qtpy():
         assert sip.getapi("QString") == 2, ("PyQt4 API version should be 2, "
                                             "instead is %s"
                                             % sip.getapi("QString"))
+
+def test_sip_api_already_set():
+    """Qt.py should cause ImportError when sip API v1 was already set"""
+
+    with pyqt4():
+        def import_qt():
+            import Qt
+
+        from PyQt4 import QtCore
+        import sip
+        sip.setapi("QString", 1)
+        assert_raises(ImportError, import_qt)

--- a/tests.py
+++ b/tests.py
@@ -15,7 +15,7 @@ from nose.tools import (
     assert_raises,
 )
 
-PY_VER_MAJOR = sys.version_info[0]  # e.g. 2 or 3
+PYTHON = sys.version_info[0]  # e.g. 2 or 3
 
 
 @contextlib.contextmanager
@@ -87,12 +87,12 @@ def test_sip_api_pyqt4():
 
     from PyQt4 import QtCore
     import sip
-    if PY_VER_MAJOR == 2:
+    if PYTHON == 2:
         # Python 2.x
         assert sip.getapi("QString") == 1, ("PyQt4 API version should be 1, "
                                             "instead is %s"
                                             % sip.getapi("QString"))
-    elif PY_VER_MAJOR == 3:
+    elif PYTHON == 3:
         # Python 3.x
         assert sip.getapi("QString") == 2, ("PyQt4 API version should be 2, "
                                             "instead is %s"
@@ -109,7 +109,7 @@ def test_sip_api_qtpy():
                                             "instead is %s"
                                             % sip.getapi("QString"))
 
-if PY_VER_MAJOR == 2:
+if PYTHON == 2:
     def test_sip_api_already_set():
         """Raise ImportError if sip API v1 was already set (Python 2.x only)"""
 

--- a/tests.py
+++ b/tests.py
@@ -10,7 +10,6 @@ import sys
 import imp
 import contextlib
 
-from nose import SkipTest
 from nose.tools import (
     with_setup,
     assert_raises,

--- a/tests.py
+++ b/tests.py
@@ -125,4 +125,4 @@ def test_sip_api_already_set():
             sip.setapi("QString", 1)
             assert_raises(ImportError, import_qt)
     else:
-        raise SkipTest("Test skipped when Python version ≠ 2.x")
+        raise SkipTest("Test skipped when Python version not equal to 2.x")

--- a/tests.py
+++ b/tests.py
@@ -115,10 +115,7 @@ if PY_VER_MAJOR == 2:
         (Python 2.x only)"""
 
         with pyqt4():
-            def import_qt():
-                import Qt
-
             from PyQt4 import QtCore
             import sip
             sip.setapi("QString", 1)
-            assert_raises(ImportError, import_qt)
+            assert_raises(ImportError, __import__, "Qt")

--- a/tests.py
+++ b/tests.py
@@ -100,7 +100,7 @@ def test_sip_api_pyqt4():
 
 
 def test_sip_api_qtpy():
-    """Qt.py with preferred binding PyQt4 should have sip version 2"""
+    """Preferred binding PyQt4 should have sip version 2"""
 
     with pyqt4():
         import Qt
@@ -111,8 +111,7 @@ def test_sip_api_qtpy():
 
 if PY_VER_MAJOR == 2:
     def test_sip_api_already_set():
-        """Qt.py should cause ImportError when sip API v1 was already set
-        (Python 2.x only)"""
+        """Raise ImportError if sip API v1 was already set (Python 2.x only)"""
 
         with pyqt4():
             from PyQt4 import QtCore


### PR DESCRIPTION
Run all tests isolated from each other.
If we wish to only see some tests run in its own subprocess, we could implement that at a later time.

Fix #56

This made it possible to also test PyQt4 for sip API v1.