### PR TITLE
Fixes #66 - Also copy binding module to __name__ in sys.modules

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -182,8 +182,6 @@ def _init():
     """
     
     # Save reference to module list
-    _mods = sys.modules
-    
     preferred = os.getenv("QT_PREFERRED_BINDING")
     verbose = os.getenv("QT_VERBOSE") is not None
 
@@ -191,7 +189,7 @@ def _init():
 
         # Debug mode, used in installer
         if preferred == "None":
-            _mods[__name__].__wrapper_version__ = __version__
+            sys.modules[__name__].__wrapper_version__ = __version__
             return
 
         available = {
@@ -205,9 +203,8 @@ def _init():
             raise ImportError("Preferred Qt binding \"%s\" "
                               "not available" % preferred)
 
-        b = available[preferred]()
-        _mods["Qt"] = b
-        _mods[__name__] = b
+        binding = available[preferred]
+        sys.modules[__name__] = binding()
         return
 
     else:
@@ -220,9 +217,7 @@ def _init():
                 sys.stdout.write("Trying %s" % binding.__name__[1:])
 
             try:
-                b = binding()
-                _mods["Qt"] = b
-                _mods[__name__] = b
+                sys.modules[__name__] = binding()
                 return
 
             except ImportError as e:

--- a/Qt.py
+++ b/Qt.py
@@ -203,6 +203,7 @@ def _init():
                               "not available" % preferred)
 
         sys.modules["Qt"] = available[preferred]()
+        sys.modules[__name__] = sys.modules["Qt"]
         return
 
     else:
@@ -216,6 +217,7 @@ def _init():
 
             try:
                 sys.modules["Qt"] = binding()
+                sys.modules[__name__] = sys.modules["Qt"]
                 return
 
             except ImportError as e:

--- a/Qt.py
+++ b/Qt.py
@@ -180,7 +180,10 @@ def _init():
     this has executed.
 
     """
-
+    
+    # Save reference to module list
+    _mods = sys.modules
+    
     preferred = os.getenv("QT_PREFERRED_BINDING")
     verbose = os.getenv("QT_VERBOSE") is not None
 
@@ -188,7 +191,7 @@ def _init():
 
         # Debug mode, used in installer
         if preferred == "None":
-            sys.modules[__name__].__wrapper_version__ = __version__
+            _mods[__name__].__wrapper_version__ = __version__
             return
 
         available = {
@@ -202,8 +205,9 @@ def _init():
             raise ImportError("Preferred Qt binding \"%s\" "
                               "not available" % preferred)
 
-        sys.modules["Qt"] = available[preferred]()
-        sys.modules[__name__] = sys.modules["Qt"]
+        b = available[preferred]()
+        _mods["Qt"] = b
+        _mods[__name__] = b
         return
 
     else:
@@ -216,8 +220,9 @@ def _init():
                 sys.stdout.write("Trying %s" % binding.__name__[1:])
 
             try:
-                sys.modules["Qt"] = binding()
-                sys.modules[__name__] = sys.modules["Qt"]
+                b = binding()
+                _mods["Qt"] = b
+                _mods[__name__] = b
                 return
 
             except ImportError as e:

--- a/Qt.py
+++ b/Qt.py
@@ -181,7 +181,6 @@ def _init():
 
     """
     
-    # Save reference to module list
     preferred = os.getenv("QT_PREFERRED_BINDING")
     verbose = os.getenv("QT_VERBOSE") is not None
 

--- a/tests.py
+++ b/tests.py
@@ -8,6 +8,9 @@ Usage:
 import os
 import sys
 import imp
+import shutil
+import tempfile
+import subprocess
 import contextlib
 
 from nose.tools import (
@@ -91,6 +94,66 @@ def test_sip_api_qtpy():
         assert sip.getapi("QString") == 2, ("PyQt4 API version should be 2, "
                                             "instead is %s"
                                             % sip.getapi("QString"))
+
+
+def test_vendoring():
+    """Qt.py may be bundled along with another library/project
+    
+    Create toy project
+    
+    from project.vendor import Qt  # Absolute
+    from .vendor import Qt         # Relative
+    
+    project/
+        vendor/
+        __init__.py
+            __init__.py
+
+    """
+    
+    dirname = os.path.dirname(__file__)
+    tempdir = tempfile.mkdtemp()
+
+    try:
+        project = os.path.join(tempdir, "myproject")
+        vendor = os.path.join(tempdir, "myproject", "vendor")
+
+        os.makedirs(vendor)
+
+        # Make packages out of folders
+        with open(os.path.join(project, "__init__.py"), "w") as f:
+            f.write("from .vendor.Qt import QtWidgets")
+
+        with open(os.path.join(vendor, "__init__.py"), "w") as f:
+            pass
+
+        shutil.copy(os.path.join(dirname, "Qt.py"),
+                    os.path.join(vendor, "Qt.py"))
+
+        print("Testing relative import..")
+        assert subprocess.call(
+            ["python", "-c", "import myproject"],
+            cwd=tempdir,
+            env={}
+        ) == 0
+
+        print("Testing absolute import..")
+        assert subprocess.call(
+            ["python", "-c", "from myproject.vendor.Qt import QtWidgets"],
+            cwd=tempdir,
+            env={}
+        ) == 0
+
+        print("Testing direct import..")
+        assert subprocess.call(
+            ["python", "-c", "import myproject.vendor.Qt"],
+            cwd=tempdir,
+            env={}
+        ) == 0
+
+    finally:
+        shutil.rmtree(tempdir)
+
 
 if PYTHON == 2:
     def test_sip_api_already_set():


### PR DESCRIPTION
This merge request fixes #66 by also setting the imported bindings module to the path of the original `__name__`, and not just "Qt"