### PR TITLE
Add CAVEATS.md

### DIFF
--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -1,0 +1,105 @@
+## Caveats
+
+There are cases where Qt.py is not handling incompatibility issues.
+
+- [Closures](CAVEATS.md#Closures)
+- [QtCore](CAVEATS.md#QtCore)
+  - [QtCore.QAbstractModel.createIndex](CAVEATS.md#QtCore.QAbstractModel.createIndex)
+  - [QtCore.QItemSelection](CAVEATS.md#QtCore.QItemSelection)
+  - [QtCore.Slot](CAVEATS.md#QtCore.Slot)
+- [QtGui](CAVEATS.md#QtGui)
+  - [QtGui.QRegExpValidator](CAVEATS.md#QtGui.QRegExpValidator)
+- [QtWidgets](CAVEATS.md#QtWidgets)
+  - [QtWidgets.QAction.triggered](CAVEATS.md#QtWidgets.QAction.triggered)
+
+## Closures
+
+```python 
+# valid in PySide
+def someMethod(self):
+    def _wrapper():
+        self.runSomething("foo")
+
+    someObject._callback = _wrapper
+    someObject.someSignal.connect(_wrapper)
+
+# In PyQt4 an exception is generated when the signal fires
+    def _wrapper():
+        self.runSomething("foo")
+NameError: free variable 'self' referenced before assignment in enclosing scope
+```
+
+## QtCore
+
+#### QtCore.QAbstractModel.createIndex
+
+In PySide, somehow the last argument (the id) is allowed to be negative and is maintained. While in PyQt4 it gets coerced into an undefined unsigned value.
+
+```python
+# PySide
+>>> idx = model.createIndex(0, 0, -1)
+>>> print idx.internalId()
+# -1
+
+# PyQt4
+>>> idx = model.createIndex(0, 0, -1)
+>>> print idx.internalId()
+# 18446744073709551615
+```
+
+> Note - I had been using the id as an index into a list. But the unexpected return value from PyQt4 broke it by being invalid. The workaround was to always check that the returned id was between 0 and the max size I expect.  
+– @justinfx
+
+#### QtCore.QItemSelection
+
+```python
+# PySide
+>>> QtGui.QItemSelection.empty()
+
+# PyQt4
+>>> QtGui.QItemSelection.isEmpty()
+```
+
+However, they both do support the len(selection) operation.
+
+
+#### QtCore.Slot
+
+PySide allows for a `result=None` keyword param to set the return type. PyQt4 crashes:
+
+```python
+>>> QtCore.Slot(QtGui.QWidget, result=None)
+TypeError: string or ASCII unicode expected not 'NoneType'
+```
+
+## QtGui
+
+#### QtGui.QRegExpValidator
+
+In PySide, the constructor for `QtGui.QRegExpValidator()` can just take a `QRegExp` instance, and that is all.
+
+In PyQt4 you are required to pass some form of a parent argument, otherwise you get a TypeError:
+
+```python
+QtGui.QRegExpValidator(regex, None)
+```
+
+
+## QtWidgets
+
+#### QtWidgets.QAction.triggered
+
+`QAction.triggered` signal requires a bool arg in PyQt4, while PySide cannot accept any arguments.
+
+```python
+# PySide
+>>> a.triggered.emit()
+>>> a.triggered.emit(True)
+TypeError: triggered() only accept 0 arguments, 2 given!
+
+# PyQt4
+>>> a.triggered.emit()
+TypeError: triggered(bool) has 1 argument(s) but 0 provided
+
+>>> a.triggered.emit(True)  # is checked
+```

--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -3,14 +3,15 @@
 There are cases where Qt.py is not handling incompatibility issues.
 
 - [Closures](CAVEATS.md#Closures)
-- [QtCore](CAVEATS.md#QtCore)
-  - [QtCore.QAbstractModel.createIndex](CAVEATS.md#QtCore.QAbstractModel.createIndex)
-  - [QtCore.QItemSelection](CAVEATS.md#QtCore.QItemSelection)
-  - [QtCore.Slot](CAVEATS.md#QtCore.Slot)
-- [QtGui](CAVEATS.md#QtGui)
-  - [QtGui.QRegExpValidator](CAVEATS.md#QtGui.QRegExpValidator)
-- [QtWidgets](CAVEATS.md#QtWidgets)
-  - [QtWidgets.QAction.triggered](CAVEATS.md#QtWidgets.QAction.triggered)
+- [QtCore.QAbstractModel.createIndex](CAVEATS.md#QtCore.QAbstractModel.createIndex)
+- [QtCore.QItemSelection](CAVEATS.md#QtCore.QItemSelection)
+- [QtCore.Slot](CAVEATS.md#QtCore.Slot)
+- [QtGui.QRegExpValidator](CAVEATS.md#QtGui.QRegExpValidator)
+- [QtWidgets.QAction.triggered](CAVEATS.md#QtWidgets.QAction.triggered)
+
+<br>
+<br>
+<br>
 
 ## Closures
 
@@ -29,7 +30,10 @@ def someMethod(self):
 NameError: free variable 'self' referenced before assignment in enclosing scope
 ```
 
-## QtCore
+<br>
+<br>
+<br>
+
 
 #### QtCore.QAbstractModel.createIndex
 
@@ -50,6 +54,10 @@ In PySide, somehow the last argument (the id) is allowed to be negative and is m
 > Note - I had been using the id as an index into a list. But the unexpected return value from PyQt4 broke it by being invalid. The workaround was to always check that the returned id was between 0 and the max size I expect.  
 – @justinfx
 
+<br>
+<br>
+<br>
+
 #### QtCore.QItemSelection
 
 ```python
@@ -62,6 +70,9 @@ In PySide, somehow the last argument (the id) is allowed to be negative and is m
 
 However, they both do support the len(selection) operation.
 
+<br>
+<br>
+<br>
 
 #### QtCore.Slot
 
@@ -72,7 +83,9 @@ PySide allows for a `result=None` keyword param to set the return type. PyQt4 cr
 TypeError: string or ASCII unicode expected not 'NoneType'
 ```
 
-## QtGui
+<br>
+<br>
+<br>
 
 #### QtGui.QRegExpValidator
 
@@ -84,8 +97,10 @@ In PyQt4 you are required to pass some form of a parent argument, otherwise you 
 QtGui.QRegExpValidator(regex, None)
 ```
 
+<br>
+<br>
+<br>
 
-## QtWidgets
 
 #### QtWidgets.QAction.triggered
 

--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -13,7 +13,7 @@ There are cases where Qt.py is not handling incompatibility issues.
 <br>
 <br>
 
-## Closures
+#### Closures
 
 ```python 
 # valid in PySide

--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -2,12 +2,12 @@
 
 There are cases where Qt.py is not handling incompatibility issues.
 
-- [Closures](CAVEATS.md#Closures)
-- [QtCore.QAbstractModel.createIndex](CAVEATS.md#QtCore.QAbstractModel.createIndex)
-- [QtCore.QItemSelection](CAVEATS.md#QtCore.QItemSelection)
-- [QtCore.Slot](CAVEATS.md#QtCore.Slot)
-- [QtGui.QRegExpValidator](CAVEATS.md#QtGui.QRegExpValidator)
-- [QtWidgets.QAction.triggered](CAVEATS.md#QtWidgets.QAction.triggered)
+- [Closures](CAVEATS.md#closures)
+- [QtCore.QAbstractModel.createIndex](CAVEATS.md#qtcoreqabstractmodelcreateindex)
+- [QtCore.QItemSelection](CAVEATS.md#qtcoreqitemselection)
+- [QtCore.Slot](CAVEATS.md#qtcoreslot)
+- [QtGui.QRegExpValidator](CAVEATS.md#qtguiqregexpvalidator)
+- [QtWidgets.QAction.triggered](CAVEATS.md#qtwidgetsqactiontriggered)
 
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ from Qt import QtCore
 from PyQt4 import QtGui
 ```
 
+**Caveats**
+
+There are cases where Qt.py is not handling incompatibility issues. Please see [`CAVEATS.md`](CAVEATS.md) for more information.
+
 <br>
 <br>
 <br>


### PR DESCRIPTION
Here's a starting point for conversation regarding https://github.com/mottosso/Qt.py/issues/65 ...

- I didn't call the file `INCOMPATIBILITIES.md` because of the long file name.
- I first added the TOC in the `README.md` but realised users may expect a TOC inside of `CAVEATS.md` and I really didn't want it in both of them for maintenance purposes.