### PR TITLE
Add map for QStringListModel

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -68,6 +68,7 @@ def _pyqt4():
     PyQt4.QtCore.Slot = PyQt4.QtCore.pyqtSlot
     PyQt4.QtCore.Property = PyQt4.QtCore.pyqtProperty
     PyQt4.QtCore.QItemSelection = PyQt4.QtGui.QItemSelection
+    PyQt4.QtCore.QStringListModel = PyQt4.QtGui.QStringListModel
     PyQt4.QtCore.QItemSelectionModel = PyQt4.QtGui.QItemSelectionModel
 
     # Add


### PR DESCRIPTION
I found that this was missing from `_pyqt4`:

    PyQt4.QtCore.QStringListModel = PyQt4.QtGui.QStringListModel

This is already in `_pyside`:

    PySide.QtCore.QStringListModel = PySide.QtGui.QStringListModel