### PR TITLE
Implement #131

### DIFF
--- a/Dockerfile-py2.7
+++ b/Dockerfile-py2.7
@@ -19,6 +19,8 @@ RUN pip install nose nosepipe
 
 # Enable additional output from Qt.py
 ENV QT_VERBOSE true
+ENV QT_TESTING true
+
 # Xvfb
 ENV DISPLAY :99
 

--- a/Dockerfile-py3.5
+++ b/Dockerfile-py3.5
@@ -19,6 +19,7 @@ RUN pip3 install nose nosepipe
 
 # Enable additional output from Qt.py
 ENV QT_VERBOSE true
+ENV QT_TESTING true
 
 # Xvfb
 ENV DISPLAY :99

--- a/Qt.py
+++ b/Qt.py
@@ -31,7 +31,7 @@ Usage:
 import os
 import sys
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 # All unique members of Qt.py
 __added__ = list()
@@ -57,7 +57,7 @@ def remap(object, name, value, safe=True):
 
     """
 
-    if safe:
+    if os.getenv("QT_TESTING") is not None and safe:
         # Cannot alter original binding.
         if hasattr(object, name):
             raise AttributeError("Cannot override existing name: "

--- a/README.md
+++ b/README.md
@@ -135,7 +135,27 @@ Using the OS path separator (`os.pathsep`) which is `:` on Unix systems and `;` 
 
 <br>
 
-##### Load Qt Designer .ui files
+##### Compile Qt Designer files
+
+> WARNING - ALPHA FUNCTIONALITY<br>
+> See [#132](https://github.com/mottosso/Qt.py/pull/132) for details.
+
+`.ui` files compiled via `pyside2-uic` inherently contain traces of PySide2 - e.g. the line `from PySide2 import QtGui`.
+
+In order to use these with Qt.py, or any other binding, one must first erase such traces and replace them with cross-compatible code.
+
+```bash
+$ pyside2-uic my_ui.ui -o my_ui.py
+$ python -m Qt --convert my_ui.py
+# Creating "my_ui_backup.py"..
+# Successfully converted "my_ui.py"
+```
+
+Now you may use the file as you normally would, with Qt.py
+
+<br>
+
+##### Load Qt Designer files
 
 The `uic.loadUi` function of PyQt4 and PyQt5 as well as the `QtUiTools.QUiLoader().load` function of PySide/PySide2 are mapped to a convenience function `load_ui`.
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ None yet.
 
 Send us a pull-request with your studio here.
 
+- Method Studios
 - Framestore
 - Weta Digital
 - Disney Animation


### PR DESCRIPTION
Allright folks, let's get this started!

This command converts a PySide2-compiled .ui file into a Qt.py-compatible equivalent.

```bash
$ pyside2-uic my_ui.ui -o my_ui.py
$ python -m Qt --convert my_ui.py
$ cat my_ui_.py
```

Tested on [this file](https://gist.github.com/salvaom/afe312982140c926c21005d822c0f116#file-widget_designer1_uic2-py).

Also includes a non command-line version.

```python
>>> import Qt
>>> Qt.convert(lines="""\
from PySide2 import QtCore, QtGui, QtWidgets

class Ui_uic(object):
    def setupUi(self, uic):
        self.retranslateUi(uic)

    def retranslateUi(self, uic):
        self.pushButton_2.setText(
            QtWidgets.QApplication.translate("uic", "NOT Ok", None, -1))
""".split("\n")
```

### What we need

1. Run this on your GUIs, see that it works 
2. Where it doesn't work, help me narrow down the exact line that breaks so we can include it.

Let me know what you think!

- #131 
