### PR TITLE
Fix #133

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -31,7 +31,7 @@ Usage:
 import os
 import sys
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 # All unique members of Qt.py
 __added__ = list()

--- a/Qt.py
+++ b/Qt.py
@@ -239,10 +239,18 @@ def init():
             )
 
     for binding in bindings:
-        log("Trying %s" % binding.__name__[1:], verbose)
+        log("Trying %s" % binding.__name__, verbose)
 
         try:
-            sys.modules[__name__] = binding()
+            binding = binding()
+
+            sys.modules.update({
+                __name__: binding,
+
+                # Fix #133, `from Qt.QtWidgets import QPushButton`
+                __name__ + ".QtWidgets": binding.QtWidgets
+            })
+
             return
 
         except ImportError as e:

--- a/run_tests.py
+++ b/run_tests.py
@@ -32,20 +32,23 @@ if __name__ == "__main__":
         "--exe",
     ]
 
-    # argv.extend(sys.argv[1:])
+    errors = 0
 
     # Running each test independently via subprocess
     # enables tests to filter out from tests.py before
     # being split into individual processes via the
     # --with-process-isolation feature of nose.
     with binding("PyQt4"):
-        subprocess.call(argv)
+        errors += subprocess.call(argv)
 
     with binding("PySide"):
-        subprocess.call(argv)
+        errors += subprocess.call(argv)
 
     with binding("PyQt5"):
-        subprocess.call(argv)
+        errors += subprocess.call(argv)
 
     with binding("PySide2"):
-        subprocess.call(argv)
+        errors += subprocess.call(argv)
+
+    if errors:
+        raise Exception("%i binding(s) failed." % errors)

--- a/tests.py
+++ b/tests.py
@@ -159,6 +159,12 @@ def test_vendoring():
     ) == 0
 
 
+def test_import_from_qtwidgets():
+    """Fix #133, `from Qt.QtWidgets import XXX` works"""
+    from Qt.QtWidgets import QPushButton
+    assert QPushButton.__name__ == "QPushButton", QPushButton
+
+
 if binding("PyQt4"):
     def test_preferred_pyqt4():
         """QT_PREFERRED_BINDING = PyQt4 properly forces the binding"""


### PR DESCRIPTION
In regards to #133, this addresses the problem of not being able to import widgets directly from `QtWidgets` with bindings for Qt 4.

```python
# Previously threw an exception
from Qt.QtWidgets import QPushButton
```

### Remarks

Though this approach works, it is rather limited to this one instance. The reason this happens in the first place is beyond me, but I suspect it has to do with how Qt.py replaces itself with the original binding.

```python
sys.modules["Qt"] = PyQt5
```

The `from XXX import YYY` syntax must be performing some processing of sorts that, in combination with the magic already happening with the compiled binding itself, must throw Python in one way or another.

With this solution, we will still not be able to to import successfully from other Qt 5-only modules, such as QtSvg and others.

The plan is that when the need arises, we will either keep patching in this way, or find an alternative route that works more globally.