### PR TITLE
Implement #139

### DIFF
--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -254,10 +254,21 @@ AttributeError: 'PySide.QtGui.QHeaderView' object has no attribute 'setSectionRe
 
 ##### Workaround
 
-Use a conditional.
+Use compatibility wrapper.
 
 ```python
 # PySide2
+>>> from Qt import QtWidgets, QtShim
+>>> app = QtWidgets.QApplication(sys.argv)
+>>> view = QtWidgets.QTreeWidget()
+>>> header = view.header()
+>>> QtShim.setSectionResizeMode(header, QtWidgets.QHeaderView.Fixed)
+```
+
+Or a conditional.
+
+```python
+# PyQt5
 >>> from Qt import QtWidgets, __binding__
 >>> app = QtWidgets.QApplication(sys.argv)
 >>> view = QtWidgets.QTreeWidget()
@@ -267,4 +278,3 @@ Use a conditional.
 ... else:
 ...   header.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
 ```
-

--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -258,11 +258,11 @@ Use compatibility wrapper.
 
 ```python
 # PySide2
->>> from Qt import QtWidgets, QtShim
+>>> from Qt import QtWidgets, QtCompat
 >>> app = QtWidgets.QApplication(sys.argv)
 >>> view = QtWidgets.QTreeWidget()
 >>> header = view.header()
->>> QtShim.setSectionResizeMode(header, QtWidgets.QHeaderView.Fixed)
+>>> QtCompat.setSectionResizeMode(header, QtWidgets.QHeaderView.Fixed)
 ```
 
 Or a conditional.

--- a/Qt.py
+++ b/Qt.py
@@ -375,6 +375,7 @@ def _maintain_backwards_compatibility(binding):
 
     for member in ("__binding__",
                    "__binding_version__",
+                   "__qt_version__",
                    "__added__",
                    "__remapped__",
                    "__modified__",
@@ -386,10 +387,6 @@ def _maintain_backwards_compatibility(binding):
 
     setattr(binding, "__wrapper_version__", self.__version__)
     self.__added__.append("__wrapper_version__")
-
-    # Related to compatibility with python-qt. See issue #135
-    setattr(binding, "__qt_version__", self.__qt_version__)
-    self.__added__.append("__qt_version__")
 
 
 cli(sys.argv[1:]) if __name__ == "__main__" else init()

--- a/Qt.py
+++ b/Qt.py
@@ -32,57 +32,21 @@ import os
 import sys
 import shutil
 
-__version__ = "0.5.0"
+self = sys.modules[__name__]
 
-# All unique members of Qt.py
-__added__ = list()
+self.__version__ = "0.6.0"
 
-# Members copied from elsewhere, such as QtGui -> QtWidgets
-__remapped__ = list()
+self.__added__ = list()     # All unique members of Qt.py
+self.__remapped__ = list()  # Members copied from elsewhere
+self.__modified__ = list()  # Existing members modified in some way
 
-# Existing members modified in some way
-__modified__ = list()
-
-
-def remap(object, name, value, safe=True):
-    """Prevent accidental assignment of existing members
-
-    Arguments:
-        object (object): Parent of new attribute
-        name (str): Name of new attribute
-        value (object): Value of new attribute
-        safe (bool): Whether or not to guarantee that
-            the new attribute was not overwritten.
-            Can be set to False under condition that
-            it is superseded by extensive testing.
-
-    """
-
-    if os.getenv("QT_TESTING") is not None and safe:
-        # Cannot alter original binding.
-        if hasattr(object, name):
-            raise AttributeError("Cannot override existing name: "
-                                 "%s.%s" % (object.__name__, name))
-
-        # Cannot alter classes of functions
-        if type(object).__name__ != "module":
-            raise AttributeError("%s != 'module': Cannot alter "
-                                 "anything but modules" % object)
-
-    elif hasattr(object, name):
-        # Keep track of modifications
-        __modified__.append(name)
-
-    if name not in __added__:
-        __remapped__.append(name)
-
-    setattr(object, name, value)
-
-
-def add(object, name, value, safe=True):
-    """Identical to :func:`remap` and provided for readability only"""
-    __added__.append(name)
-    remap(object, name, value, safe)
+# Below members are set dynamically on import relative the original binding.
+self.__qt_version__ = "0.0.0"
+self.__binding__ = "None"
+self.__binding_version__ = "0.0.0"
+self.load_ui = lambda fname: None
+self.translate = lambda context, sourceText, disambiguation, n: None
+self.setSectionResizeMode = lambda *args, **kwargs: None
 
 
 def convert(lines):
@@ -110,31 +74,69 @@ def convert(lines):
     return parsed
 
 
-def pyqt5():
+def _remap(object, name, value, safe=True):
+    """Prevent accidental assignment of existing members
+
+    Arguments:
+        object (object): Parent of new attribute
+        name (str): Name of new attribute
+        value (object): Value of new attribute
+        safe (bool): Whether or not to guarantee that
+            the new attribute was not overwritten.
+            Can be set to False under condition that
+            it is superseded by extensive testing.
+
+    """
+
+    if os.getenv("QT_TESTING") is not None and safe:
+        # Cannot alter original binding.
+        if hasattr(object, name):
+            raise AttributeError("Cannot override existing name: "
+                                 "%s.%s" % (object.__name__, name))
+
+        # Cannot alter classes of functions
+        if type(object).__name__ != "module":
+            raise AttributeError("%s != 'module': Cannot alter "
+                                 "anything but modules" % object)
+
+    elif hasattr(object, name):
+        # Keep track of modifications
+        self.__modified__.append(name)
+
+    self.__remapped__.append(name)
+
+    setattr(object, name, value)
+
+
+def _add(object, name, value):
+    """Append to self, accessible via Qt.QtShim"""
+    self.__added__.append(name)
+    setattr(self, name, value)
+
+
+def _pyqt5():
     import PyQt5.Qt
-    from PyQt5 import QtCore, uic
+    from PyQt5 import QtCore, QtWidgets, uic
 
-    remap(QtCore, "Signal", QtCore.pyqtSignal)
-    remap(QtCore, "Slot", QtCore.pyqtSlot)
-    remap(QtCore, "Property", QtCore.pyqtProperty)
+    _remap(QtCore, "Signal", QtCore.pyqtSignal)
+    _remap(QtCore, "Slot", QtCore.pyqtSlot)
+    _remap(QtCore, "Property", QtCore.pyqtProperty)
 
-    add(PyQt5, "__wrapper_version__", __version__)
-    add(PyQt5, "__binding__", "PyQt5")
-    add(PyQt5, "__binding_version__", QtCore.PYQT_VERSION_STR)
-    add(PyQt5, "__qt_version__", QtCore.QT_VERSION_STR, safe=False)
-    add(PyQt5, "__added__", __added__)
-    add(PyQt5, "__remapped__", __remapped__)
-    add(PyQt5, "__modified__", __modified__)
-    add(PyQt5, "load_ui", lambda fname: uic.loadUi(fname))
-    add(PyQt5, "convert", convert)
-    add(PyQt5, "translate", lambda
-        context, sourceText, disambiguation, n: QtCore.QCoreApplication(
-            context, sourceText, disambiguation, n))
+    _add(PyQt5, "__binding__", PyQt5.__name__)
+    _add(PyQt5, "load_ui", lambda fname: uic.loadUi(fname))
+    _add(PyQt5, "translate", lambda context, sourceText, disambiguation, n: (
+        QtCore.QCoreApplication(context, sourceText,
+                                disambiguation, n)))
+    _add(PyQt5,
+         "setSectionResizeMode",
+         QtWidgets.QHeaderView.setSectionResizeMode)
+
+    _maintain_backwards_compatibility(PyQt5)
 
     return PyQt5
 
 
-def pyqt4():
+def _pyqt4():
     # Attempt to set sip API v2 (must be done prior to importing PyQt4)
     import sip
     try:
@@ -155,98 +157,89 @@ def pyqt4():
     import PyQt4.Qt
     from PyQt4 import QtCore, QtGui, uic
 
-    remap(PyQt4, "QtWidgets", QtGui)
-    remap(QtCore, "Signal", QtCore.pyqtSignal)
-    remap(QtCore, "Slot", QtCore.pyqtSlot)
-    remap(QtCore, "Property", QtCore.pyqtProperty)
-    remap(QtCore, "QItemSelection", QtGui.QItemSelection)
-    remap(QtCore, "QStringListModel", QtGui.QStringListModel)
-    remap(QtCore, "QItemSelectionModel", QtGui.QItemSelectionModel)
-    remap(QtCore, "QSortFilterProxyModel", QtGui.QSortFilterProxyModel)
-    remap(QtCore, "QAbstractProxyModel", QtGui.QAbstractProxyModel)
+    _remap(PyQt4, "QtWidgets", QtGui)
+    _remap(QtCore, "Signal", QtCore.pyqtSignal)
+    _remap(QtCore, "Slot", QtCore.pyqtSlot)
+    _remap(QtCore, "Property", QtCore.pyqtProperty)
+    _remap(QtCore, "QItemSelection", QtGui.QItemSelection)
+    _remap(QtCore, "QStringListModel", QtGui.QStringListModel)
+    _remap(QtCore, "QItemSelectionModel", QtGui.QItemSelectionModel)
+    _remap(QtCore, "QSortFilterProxyModel", QtGui.QSortFilterProxyModel)
+    _remap(QtCore, "QAbstractProxyModel", QtGui.QAbstractProxyModel)
 
     try:
         from PyQt4 import QtWebKit
-        remap(PyQt4, "QtWebKitWidgets", QtWebKit)
+        _remap(PyQt4, "QtWebKitWidgets", QtWebKit)
     except ImportError:
         # QtWebkit is optional in Qt , therefore might not be available
         pass
 
-    add(PyQt4, "__wrapper_version__", __version__)
-    add(PyQt4, "__binding__", "PyQt4")
-    add(PyQt4, "__binding_version__", QtCore.PYQT_VERSION_STR)
-    add(PyQt4, "__qt_version__", QtCore.QT_VERSION_STR)
-    add(PyQt4, "__added__", __added__)
-    add(PyQt4, "__remapped__", __remapped__)
-    add(PyQt4, "__modified__", __modified__)
-    add(PyQt4, "load_ui", lambda fname: uic.loadUi(fname))
-    add(PyQt4, "convert", convert)
-    add(PyQt4, "translate", lambda
-        context, sourceText, disambiguation, n: QtCore.QCoreApplication(
-            context, sourceText, disambiguation, None, n))
+    _add(PyQt4, "QtShim", self)
+    _add(PyQt4, "__binding__", PyQt4.__name__)
+    _add(PyQt4, "load_ui", lambda fname: uic.loadUi(fname))
+    _add(PyQt4, "translate", lambda context, sourceText, disambiguation, n: (
+        QtCore.QCoreApplication(context, sourceText,
+                                disambiguation, None, n)))
+    _add(PyQt4, "setSectionResizeMode", QtGui.QHeaderView.setResizeMode)
+
+    _maintain_backwards_compatibility(PyQt4)
 
     return PyQt4
 
 
-def pyside2():
+def _pyside2():
     import PySide2
-    from PySide2 import QtGui, QtCore, QtUiTools
+    from PySide2 import QtGui, QtWidgets, QtCore, QtUiTools
 
-    remap(QtCore, "QStringListModel", QtGui.QStringListModel)
+    _remap(QtCore, "QStringListModel", QtGui.QStringListModel)
 
-    add(PySide2, "__wrapper_version__", __version__)
-    add(PySide2, "__binding__", "PySide2")
-    add(PySide2, "__binding_version__", PySide2.__version__)
-    add(PySide2, "__qt_version__", PySide2.QtCore.qVersion())
-    add(PySide2, "__added__", __added__)
-    add(PySide2, "__remapped__", __remapped__)
-    add(PySide2, "__modified__", __modified__)
-    add(PySide2, "load_ui", lambda fname: QtUiTools.QUiLoader().load(fname))
-    add(PySide2, "convert", convert)
-    add(PySide2, "translate", lambda
-        context, sourceText, disambiguation, n: QtCore.QCoreApplication(
-            context, sourceText, disambiguation, n))
+    _add(PySide2, "__binding__", PySide2.__name__)
+    _add(PySide2, "load_ui", lambda fname: QtUiTools.QUiLoader().load(fname))
+    _add(PySide2, "translate", lambda context, sourceText, disambiguation, n: (
+        QtCore.QCoreApplication(context, sourceText,
+                                disambiguation, None, n)))
+    _add(PySide2,
+         "setSectionResizeMode",
+         QtWidgets.QHeaderView.setSectionResizeMode)
+
+    _maintain_backwards_compatibility(PySide2)
 
     return PySide2
 
 
-def pyside():
+def _pyside():
     import PySide
     from PySide import QtGui, QtCore, QtUiTools
 
-    remap(PySide, "QtWidgets", QtGui)
-    remap(QtCore, "QSortFilterProxyModel", QtGui.QSortFilterProxyModel)
-    remap(QtCore, "QStringListModel", QtGui.QStringListModel)
-    remap(QtCore, "QItemSelection", QtGui.QItemSelection)
-    remap(QtCore, "QItemSelectionModel", QtGui.QItemSelectionModel)
-    remap(QtCore, "QAbstractProxyModel", QtGui.QAbstractProxyModel)
+    _remap(PySide, "QtWidgets", QtGui)
+    _remap(QtCore, "QSortFilterProxyModel", QtGui.QSortFilterProxyModel)
+    _remap(QtCore, "QStringListModel", QtGui.QStringListModel)
+    _remap(QtCore, "QItemSelection", QtGui.QItemSelection)
+    _remap(QtCore, "QItemSelectionModel", QtGui.QItemSelectionModel)
+    _remap(QtCore, "QAbstractProxyModel", QtGui.QAbstractProxyModel)
 
     try:
         from PySide import QtWebKit
-        remap(PySide, "QtWebKitWidgets", QtWebKit)
+        _remap(PySide, "QtWebKitWidgets", QtWebKit)
     except ImportError:
-        # QtWebkit is optional in Qt , therefore might not be available
+        # QtWebkit is optional in Qt, therefore might not be available
         pass
 
-    add(PySide, "__wrapper_version__", __version__)
-    add(PySide, "__binding__", "PySide")
-    add(PySide, "__binding_version__", PySide.__version__)
-    add(PySide, "__qt_version__", PySide.QtCore.qVersion())
-    add(PySide, "__added__", __added__)
-    add(PySide, "__remapped__", __remapped__)
-    add(PySide, "__modified__", __modified__)
-    add(PySide, "load_ui", lambda fname: QtUiTools.QUiLoader().load(fname))
-    add(PySide, "convert", convert)
-    add(PySide, "translate", lambda
-        context, sourceText, disambiguation, n: QtCore.QCoreApplication(
-            context, sourceText, disambiguation, None, n))
+    _add(PySide, "__binding__", PySide.__name__)
+    _add(PySide, "load_ui", lambda fname: QtUiTools.QUiLoader().load(fname))
+    _add(PySide, "translate", lambda context, sourceText, disambiguation, n: (
+        QtCore.QCoreApplication(context, sourceText,
+                                disambiguation, None, n)))
+    _add(PySide, "setSectionResizeMode", QtGui.QHeaderView.setResizeMode)
+
+    _maintain_backwards_compatibility(PySide)
 
     return PySide
 
 
-def log(text, verbose):
+def _log(text, verbose):
     if verbose:
-        sys.stdout.write(text)
+        sys.stdout.write(text + "\n")
 
 
 def cli(args):
@@ -319,20 +312,20 @@ def init():
 
     preferred = os.getenv("QT_PREFERRED_BINDING")
     verbose = os.getenv("QT_VERBOSE") is not None
-    bindings = (pyside2, pyqt5, pyside, pyqt4)
+    bindings = (_pyside2, _pyqt5, _pyside, _pyqt4)
 
     if preferred:
         # Internal flag (used in installer)
         if preferred == "None":
-            sys.modules[__name__].__wrapper_version__ = __version__
+            self.__wrapper_version__ = self.__version__
             return
 
         preferred = preferred.split(os.pathsep)
         available = {
-            "PySide2": pyside2,
-            "PyQt5": pyqt5,
-            "PySide": pyside,
-            "PyQt4": pyqt4
+            "PySide2": _pyside2,
+            "PyQt5": _pyqt5,
+            "PySide": _pyside,
+            "PyQt4": _pyqt4
         }
 
         try:
@@ -344,18 +337,19 @@ def init():
             )
 
     for binding in bindings:
-        log("Trying %s" % binding.__name__, verbose)
+        _log("Trying %s" % binding.__name__, verbose)
 
         try:
             binding = binding()
 
         except ImportError as e:
-            log(" - ImportError(\"%s\")\n" % e, verbose)
+            _log(" - ImportError(\"%s\")" % e, verbose)
             continue
 
         else:
             # Reference to this module
-            binding.__shim__ = sys.modules[__name__]
+            binding.__shim__ = self
+            binding.QtShim = self
 
             sys.modules.update({
                 __name__: binding,
@@ -369,6 +363,33 @@ def init():
 
     # If not binding were found, throw this error
     raise ImportError("No Qt binding were found.")
+
+
+def _maintain_backwards_compatibility(binding):
+    """Add members found in prior versions up till the next major release
+
+    These members are to be considered deprecated. When a new major
+    release is made, these members are removed.
+
+    """
+
+    for member in ("__binding__",
+                   "__binding_version__",
+                   "__added__",
+                   "__remapped__",
+                   "__modified__",
+                   "convert",
+                   "load_ui",
+                   "translate"):
+        setattr(binding, member, getattr(self, member))
+        self.__added__.append(member)
+
+    setattr(binding, "__wrapper_version__", self.__version__)
+    self.__added__.append("__wrapper_version__")
+
+    # Related to compatibility with python-qt. See issue #135
+    setattr(binding, "__qt_version__", self.__qt_version__)
+    self.__added__.append("__qt_version__")
 
 
 cli(sys.argv[1:]) if __name__ == "__main__" else init()

--- a/Qt.py
+++ b/Qt.py
@@ -109,7 +109,7 @@ def _remap(object, name, value, safe=True):
 
 
 def _add(object, name, value):
-    """Append to self, accessible via Qt.QtShim"""
+    """Append to self, accessible via Qt.QtCompat"""
     self.__added__.append(name)
     setattr(self, name, value)
 
@@ -174,7 +174,7 @@ def _pyqt4():
         # QtWebkit is optional in Qt , therefore might not be available
         pass
 
-    _add(PyQt4, "QtShim", self)
+    _add(PyQt4, "QtCompat", self)
     _add(PyQt4, "__binding__", PyQt4.__name__)
     _add(PyQt4, "load_ui", lambda fname: uic.loadUi(fname))
     _add(PyQt4, "translate", lambda context, sourceText, disambiguation, n: (
@@ -349,7 +349,7 @@ def init():
         else:
             # Reference to this module
             binding.__shim__ = self
-            binding.QtShim = self
+            binding.QtCompat = self
 
             sys.modules.update({
                 __name__: binding,

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ app.exec_()
 
 ### Documentation
 
-All members of `Qt` stem directly from those available via PySide2, along with these additional members.
+All members of `Qt` stem directly from those available via PySide2, along with these additional members, accessible via `Qt.QtShim`.
 
 | Attribute               | Returns     | Description
 |:------------------------|:------------|:------------
@@ -92,8 +92,21 @@ All members of `Qt` stem directly from those available via PySide2, along with t
 | `__added__`             | `list(str)` | All unique members of Qt.py
 | `__remapped__`          | `list(str)` | Members copied from elsewhere, such as QtGui -> QtWidgets
 | `__modified__`          | `list(str)` | Existing members modified in some way
-| `__shim__`              | `str`       | Reference to original Qt.py Python module
+| `__shim__`              | `module`    | Reference to original Qt.py Python module
 | `load_ui(fname=str)`    | `QObject`   | Minimal wrapper of PyQt4.loadUi and PySide equivalent
+| `translate(...)`        | `function`  | Compatibility wrapper around [QCoreApplication.translate][]
+| `setSectionResizeMode()`| `method`    | Compatibility wrapper around [QAbstractItemView.setSectionResizeMode][]
+
+[QCoreApplication.translate]: https://doc.qt.io/qt-5/qcoreapplication.html#translate
+[QAbstractItemView.setSectionResizeMode]: https://doc.qt.io/qt-5/qheaderview.html#setSectionResizeMode
+
+**Example**
+
+```python
+>>> from Qt import QtShim
+>>> QtShim.__binding__
+'PyQt5'
+```
 
 <br>
 
@@ -102,7 +115,7 @@ All members of `Qt` stem directly from those available via PySide2, along with t
 Some bindings offer features not available in others, you can use `__binding__` to capture those.
 
 ```python
-if "PySide" in Qt.__binding__:
+if "PySide" in QtShim.__binding__:
   do_pyside_stuff()
 ```
 
@@ -113,14 +126,9 @@ if "PySide" in Qt.__binding__:
 If your system has multiple choices where one or more is preferred, you can override the preference and order in which they are tried with this environment variable.
 
 ```bash
-# Windows
-$ set QT_PREFERRED_BINDING=PyQt5
-$ python -c "import Qt;print(Qt.__binding__)"
-PyQt5
-
-# Unix/OSX
-$ export QT_PREFERRED_BINDING=PyQt5
-$ python -c "import Qt;print(Qt.__binding__)"
+$ set QT_PREFERRED_BINDING=PyQt5  # Windows
+$ export QT_PREFERRED_BINDING=PyQt5  # Unix/OSX
+$ python -c "from Qt import QtShim;print(QtShim.__binding__)"
 PyQt5
 ```
 
@@ -161,10 +169,10 @@ The `uic.loadUi` function of PyQt4 and PyQt5 as well as the `QtUiTools.QUiLoader
 
 ```python
 import sys
-import Qt
+from Qt import QtShim
 
 app = QtWidgets.QApplication(sys.argv)
-ui = Qt.load_ui(fname="my.ui")
+ui = QtShim.load_ui(fname="my.ui")
 ui.show()
 app.exec_()
 ```

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ app.exec_()
 
 ### Documentation
 
-All members of `Qt` stem directly from those available via PySide2, along with these additional members, accessible via `Qt.QtShim`.
+All members of `Qt` stem directly from those available via PySide2, along with these additional members, accessible via `Qt.QtCompat`.
 
 | Attribute               | Returns     | Description
 |:------------------------|:------------|:------------
@@ -103,8 +103,8 @@ All members of `Qt` stem directly from those available via PySide2, along with t
 **Example**
 
 ```python
->>> from Qt import QtShim
->>> QtShim.__binding__
+>>> from Qt import QtCompat
+>>> QtCompat.__binding__
 'PyQt5'
 ```
 
@@ -115,7 +115,7 @@ All members of `Qt` stem directly from those available via PySide2, along with t
 Some bindings offer features not available in others, you can use `__binding__` to capture those.
 
 ```python
-if "PySide" in QtShim.__binding__:
+if "PySide" in QtCompat.__binding__:
   do_pyside_stuff()
 ```
 
@@ -128,7 +128,7 @@ If your system has multiple choices where one or more is preferred, you can over
 ```bash
 $ set QT_PREFERRED_BINDING=PyQt5  # Windows
 $ export QT_PREFERRED_BINDING=PyQt5  # Unix/OSX
-$ python -c "from Qt import QtShim;print(QtShim.__binding__)"
+$ python -c "from Qt import QtCompat;print(QtCompat.__binding__)"
 PyQt5
 ```
 
@@ -169,10 +169,10 @@ The `uic.loadUi` function of PyQt4 and PyQt5 as well as the `QtUiTools.QUiLoader
 
 ```python
 import sys
-from Qt import QtShim
+from Qt import QtCompat
 
 app = QtWidgets.QApplication(sys.argv)
-ui = QtShim.load_ui(fname="my.ui")
+ui = QtCompat.load_ui(fname="my.ui")
 ui.show()
 app.exec_()
 ```
@@ -339,6 +339,30 @@ Send us a pull-request with your project here.
 <br>
 
 ### Developer Guide
+
+Tests are performed on each aspect of the shim.
+
+- [Functional](tests.py)
+- [Caveats](build_caveats.py)
+- [Examples](examples)
+- [Membership](build_membership.py)
+
+Each of these are run under..
+
+- Python 2.7
+- Python 3.4
+
+..once for each binding or under a specific binding only.
+
+Tests that are written at module level are run four times - once per binding - whereas tests written under a specific if-statement are run only for this particular binding.
+
+```python
+if binding("PyQt4"):
+	def test_something_related_to_pyqt4():
+		pass
+```
+
+**Running tests**
 
 Due to the nature of multiple bindings and multiple interpreter support, setting up a development environment in which to properly test your contraptions can be challenging. So here is a guide for how to do just that using **Docker**.
 

--- a/README.md
+++ b/README.md
@@ -354,6 +354,8 @@ Each of these are run under..
 
 ..once for each binding or under a specific binding only.
 
+Each test is run within it's own isolated process, so as to allow an `import` to occur independently from other tests. Process isolation is handled via [nosepipe](https://pypi.python.org/pypi/nosepipe).
+
 Tests that are written at module level are run four times - once per binding - whereas tests written under a specific if-statement are run only for this particular binding.
 
 ```python

--- a/tests.py
+++ b/tests.py
@@ -219,15 +219,15 @@ class Ui_uic(object):
     with open(fname, "w") as f:
         f.write(before)
 
-    import Qt
+    from Qt import QtShim
 
     os.chdir(self.tempdir)
-    Qt.__shim__.cli(args=["--convert", "idempotency.py"])
+    QtShim.cli(args=["--convert", "idempotency.py"])
 
     with open(fname) as f:
         assert f.read() == after
 
-    Qt.__shim__.cli(args=["--convert", "idempotency.py"])
+    QtShim.cli(args=["--convert", "idempotency.py"])
 
     with open(fname) as f:
         assert f.read() == after
@@ -240,10 +240,10 @@ def test_convert_backup():
     with open(fname, "w") as f:
         f.write("")
 
-    import Qt
+    from Qt import QtShim
 
     os.chdir(self.tempdir)
-    Qt.__shim__.cli(args=["--convert", "idempotency.py"])
+    QtShim.cli(args=["--convert", "idempotency.py"])
 
     assert os.path.exists(
         os.path.join(self.tempdir, "%s_backup%s" % os.path.splitext(fname))
@@ -251,57 +251,53 @@ def test_convert_backup():
 
 
 def test_meta_add():
-    """Qt.add() appends to __added__"""
-    import types
-    import Qt
+    """Qt._add() appends to __added__"""
+    from Qt import QtShim
 
     module = imp.new_module("QtMock")
 
-    Qt.__shim__.add(module, "MyAttr", None)
+    QtShim._add(module, "MyAttr", None)
 
-    assert "MyAttr" in Qt.__added__, Qt.__added__
-    assert "MyAttr" not in Qt.__remapped__
-    assert "MyAttr" not in Qt.__modified__
+    assert "MyAttr" in QtShim.__added__, QtShim.__added__
+    assert "MyAttr" not in QtShim.__remapped__
+    assert "MyAttr" not in QtShim.__modified__
+
 
 def test_meta_remap():
-    """Qt.remap() appends to __modified__"""
-    import types
-    import Qt
+    """Qt._remap() appends to __modified__"""
+    from Qt import QtShim
 
     module = imp.new_module("QtMock")
 
-    Qt.__shim__.remap(module, "MyAttr", None)
+    QtShim._remap(module, "MyAttr", None)
 
-    assert "MyAttr" not in Qt.__added__, Qt.__added__
-    assert "MyAttr" in Qt.__remapped__
-    assert "MyAttr" not in Qt.__modified__
+    assert "MyAttr" not in QtShim.__added__, QtShim.__added__
+    assert "MyAttr" in QtShim.__remapped__
+    assert "MyAttr" not in QtShim.__modified__
 
 
-
-def test_meta_add_existing():
-    """Qt.add() appends to __added__"""
-    import types
-    import Qt
+def test_meta_remap_existing():
+    """Qt._remap() of existing member throws an exception"""
+    from Qt import QtShim
 
     module = imp.new_module("QtMock")
     module.MyAttr = None
 
-    assert_raises(AttributeError, Qt.__shim__.add, module, "MyAttr", None)
+    assert_raises(AttributeError, QtShim._remap, module, "MyAttr", None)
 
 
-def test_meta_force_add_existing():
-    """Unsafe Qt.add() of existing member adds to modified"""
-    import types
-    import Qt
+def test_meta_force_remap_existing():
+    """Unsafe Qt._remap() of existing member adds to modified"""
+    from Qt import QtShim
 
     module = imp.new_module("QtMock")
     module.MyAttr = 123
 
-    Qt.__shim__.add(module, "MyAttr", None, safe=False)
+    QtShim._remap(module, "MyAttr", None, safe=False)
 
-    assert "MyAttr" in Qt.__added__, Qt.__added__
-    assert "MyAttr" not in Qt.__remapped__
-    assert "MyAttr" in Qt.__modified__
+    assert "MyAttr" in QtShim.__remapped__, QtShim.__remapped__
+    assert "MyAttr" not in QtShim.__added__
+    assert "MyAttr" in QtShim.__modified__
     assert module.MyAttr is None, module.MyAttr
 
 

--- a/tests.py
+++ b/tests.py
@@ -219,15 +219,15 @@ class Ui_uic(object):
     with open(fname, "w") as f:
         f.write(before)
 
-    from Qt import QtShim
+    from Qt import QtCompat
 
     os.chdir(self.tempdir)
-    QtShim.cli(args=["--convert", "idempotency.py"])
+    QtCompat.cli(args=["--convert", "idempotency.py"])
 
     with open(fname) as f:
         assert f.read() == after
 
-    QtShim.cli(args=["--convert", "idempotency.py"])
+    QtCompat.cli(args=["--convert", "idempotency.py"])
 
     with open(fname) as f:
         assert f.read() == after
@@ -240,10 +240,10 @@ def test_convert_backup():
     with open(fname, "w") as f:
         f.write("")
 
-    from Qt import QtShim
+    from Qt import QtCompat
 
     os.chdir(self.tempdir)
-    QtShim.cli(args=["--convert", "idempotency.py"])
+    QtCompat.cli(args=["--convert", "idempotency.py"])
 
     assert os.path.exists(
         os.path.join(self.tempdir, "%s_backup%s" % os.path.splitext(fname))
@@ -252,52 +252,52 @@ def test_convert_backup():
 
 def test_meta_add():
     """Qt._add() appends to __added__"""
-    from Qt import QtShim
+    from Qt import QtCompat
 
     module = imp.new_module("QtMock")
 
-    QtShim._add(module, "MyAttr", None)
+    QtCompat._add(module, "MyAttr", None)
 
-    assert "MyAttr" in QtShim.__added__, QtShim.__added__
-    assert "MyAttr" not in QtShim.__remapped__
-    assert "MyAttr" not in QtShim.__modified__
+    assert "MyAttr" in QtCompat.__added__, QtCompat.__added__
+    assert "MyAttr" not in QtCompat.__remapped__
+    assert "MyAttr" not in QtCompat.__modified__
 
 
 def test_meta_remap():
     """Qt._remap() appends to __modified__"""
-    from Qt import QtShim
+    from Qt import QtCompat
 
     module = imp.new_module("QtMock")
 
-    QtShim._remap(module, "MyAttr", None)
+    QtCompat._remap(module, "MyAttr", None)
 
-    assert "MyAttr" not in QtShim.__added__, QtShim.__added__
-    assert "MyAttr" in QtShim.__remapped__
-    assert "MyAttr" not in QtShim.__modified__
+    assert "MyAttr" not in QtCompat.__added__, QtCompat.__added__
+    assert "MyAttr" in QtCompat.__remapped__
+    assert "MyAttr" not in QtCompat.__modified__
 
 
 def test_meta_remap_existing():
     """Qt._remap() of existing member throws an exception"""
-    from Qt import QtShim
+    from Qt import QtCompat
 
     module = imp.new_module("QtMock")
     module.MyAttr = None
 
-    assert_raises(AttributeError, QtShim._remap, module, "MyAttr", None)
+    assert_raises(AttributeError, QtCompat._remap, module, "MyAttr", None)
 
 
 def test_meta_force_remap_existing():
     """Unsafe Qt._remap() of existing member adds to modified"""
-    from Qt import QtShim
+    from Qt import QtCompat
 
     module = imp.new_module("QtMock")
     module.MyAttr = 123
 
-    QtShim._remap(module, "MyAttr", None, safe=False)
+    QtCompat._remap(module, "MyAttr", None, safe=False)
 
-    assert "MyAttr" in QtShim.__remapped__, QtShim.__remapped__
-    assert "MyAttr" not in QtShim.__added__
-    assert "MyAttr" in QtShim.__modified__
+    assert "MyAttr" in QtCompat.__remapped__, QtCompat.__remapped__
+    assert "MyAttr" not in QtCompat.__added__
+    assert "MyAttr" in QtCompat.__modified__
     assert module.MyAttr is None, module.MyAttr
 
 


### PR DESCRIPTION
This introduces a radical change to counter #139, #109, #112 and #96.

The change involves moving all added members of Qt.py to it's own individual module, `QtShim`.

```python
# Before
import Qt
Qt.setSectionResizeMode()
Qt.__binding__

# After
from Qt import QtShim
QtShim.setSectionResizeMode()
QtShim.__binding__ == "PyQt5"
```

- See [Example](https://github.com/abstractfactory/Qt.py/blob/master/CAVEATS.md#workaround-1)

It also counteracts our current Achilles heel, which is that at some point one of our additions are bound to conflict with native existing members of the binding. For example, if one day PySide decides to add `__qt_version__` to their offering, but have a different type for it, like `tuple`, whereas we have `str`

So I'm on the fence about whether this is the right way to do it. The disadvantage is a more complex code base; the reader must now understand how `self` plays a part, and how `QtShim` even makes it into the `Qt` namespace.

So let me know what you think.