### PR TITLE
Fix #154

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -223,7 +223,7 @@ def _pyqt4():
          QtCore.QCoreApplication.translate(context,
                                            sourceText,
                                            disambiguation,
-                                           None,
+                                           QtCore.QCoreApplication.CodecForTr,
                                            n))
 
     _maintain_backwards_compatibility(PyQt4)
@@ -248,7 +248,7 @@ def _pyside2():
          QtCore.QCoreApplication.translate(context,
                                            sourceText,
                                            disambiguation,
-                                           None,
+                                           QtCore.QCoreApplication.CodecForTr,
                                            n))
 
     _maintain_backwards_compatibility(PySide2)

--- a/Qt.py
+++ b/Qt.py
@@ -243,13 +243,7 @@ def _pyside2():
     _add(QtCompat, "setSectionResizeMode",
          QtWidgets.QHeaderView.setSectionResizeMode)
 
-    _add(QtCompat, "translate",
-         lambda context, sourceText, disambiguation, n:
-         QtCore.QCoreApplication.translate(context,
-                                           sourceText,
-                                           disambiguation,
-                                           QtCore.QCoreApplication.CodecForTr,
-                                           n))
+    _add(QtCompat, "translate", QtCore.QCoreApplication.translate)
 
     _maintain_backwards_compatibility(PySide2)
 

--- a/Qt.py
+++ b/Qt.py
@@ -285,7 +285,7 @@ def _pyside():
          QtCore.QCoreApplication.translate(context,
                                            sourceText,
                                            disambiguation,
-                                           None,
+                                           QtCore.QCoreApplication.CodecForTr,
                                            n))
 
     _maintain_backwards_compatibility(PySide)

--- a/Qt.py
+++ b/Qt.py
@@ -69,7 +69,7 @@ self.__remapped__ = list()  # Members copied from elsewhere
 self.__modified__ = list()  # Existing members modified in some way
 
 # Below members are set dynamically on import relative the original binding.
-self.__version__ = "0.6.3"
+self.__version__ = "0.6.4"
 self.__qt_version__ = "0.0.0"
 self.__binding__ = "None"
 self.__binding_version__ = "0.0.0"

--- a/tests.py
+++ b/tests.py
@@ -307,6 +307,25 @@ def test_import_from_qtwidgets():
     assert QPushButton.__name__ == "QPushButton", QPushButton
 
 
+def test_translate_arguments():
+    """Arguments of QtCompat.translate are correct
+    
+    QtCompat.translate is a shim over the PySide, PyQt4 and PyQt5
+    equivalent with an interface like the one found in PySide2.
+    
+    Reference: https://doc.qt.io/qt-5/qcoreapplication.html#translate
+    """
+    
+    import Qt
+    
+    # This will run on each binding
+    result = Qt.QtCompat.translate(context="CustomDialog",
+                                   sourceText="Status",
+                                   disambiguation=None,
+                                   n=-1)
+    assert result == u'Status', result
+
+
 if binding("PyQt4"):
     def test_preferred_pyqt4():
         """QT_PREFERRED_BINDING = PyQt4 properly forces the binding"""

--- a/tests.py
+++ b/tests.py
@@ -319,10 +319,10 @@ def test_translate_arguments():
     import Qt
     
     # This will run on each binding
-    result = Qt.QtCompat.translate(context="CustomDialog",
-                                   sourceText="Status",
-                                   disambiguation=None,
-                                   n=-1)
+    result = Qt.QtCompat.translate("CustomDialog",  # context
+                                   "Status",        # sourceText
+                                   None,            # disambiguation
+                                   -1)              # n
     assert result == u'Status', result
 
 


### PR DESCRIPTION
Fix #154

This will need some testing, but I narrowed the problem down to passing `None` where there needed to be a pre-defined variable. In this case I passed `QtCore.QCoreApplication.CodecForTr` which according to the [PySide docs](https://srinikom.github.io/pyside-docs/PySide/QtCore/QCoreApplication.html#PySide.QtCore.PySide.QtCore.QCoreApplication.translate) is the default.