### PR TITLE
Universal wheel: attempt abide PEP440

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -69,7 +69,7 @@ self.__remapped__ = list()  # Members copied from elsewhere
 self.__modified__ = list()  # Existing members modified in some way
 
 # Below members are set dynamically on import relative the original binding.
-self.__version__ = "0.6.8-test-01"
+self.__version__ = "0.6.8.dev1"
 self.__qt_version__ = "0.0.0"
 self.__binding__ = "None"
 self.__binding_version__ = "0.0.0"


### PR DESCRIPTION
Continuing attending #162 #163.

According to PEP440, this is the naming convention for a [developmental release](https://www.python.org/dev/peps/pep-0440/#developmental-releases), which we didn't follow in the previous attempt to upload a dev release to PyPi.

> X.Y.devN    # Developmental release
>
> X.YaN.devM       # Developmental release of an alpha release
> X.YbN.devM       # Developmental release of a beta release
> X.YrcN.devM      # Developmental release of a release candidate
> X.Y.postN.devM   # Developmental release of a post-release