### PR TITLE
fix QT_TESTING test 

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -69,7 +69,7 @@ self.__remapped__ = list()  # Members copied from elsewhere
 self.__modified__ = list()  # Existing members modified in some way
 
 # Below members are set dynamically on import relative the original binding.
-self.__version__ = "0.6.8"
+self.__version__ = "0.6.9"
 self.__qt_version__ = "0.0.0"
 self.__binding__ = "None"
 self.__binding_version__ = "0.0.0"

--- a/Qt.py
+++ b/Qt.py
@@ -124,7 +124,7 @@ def _remap(object, name, value, safe=True):
 
     """
 
-    if QT_TESTING is not None and safe:
+    if QT_TESTING and safe:
         # Cannot alter original binding.
         if hasattr(object, name):
             raise AttributeError("Cannot override existing name: "


### PR DESCRIPTION
Hello

We are trying to unify our Qt UI tools to Qt.py.
It seems testing of QT_TESTING in _remap() function always returns True as it is tested against None but the bool() call converts None to False.
Here is my simple fixing.

If possible, could you specify more explicitly the expected or valid values for QT_VERBOSE, QT_TESTING, like on/off or 0/1? I think this would make things clearer.

Thanks,
Sol Kim.