### PR TITLE
Implement #152

### DIFF
--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -121,15 +121,15 @@ PySide allows for a `result=None` keyword param to set the return type. PyQt4 cr
 
 ```python
 # PySide
->>> from Qt import QtCore, QtGui
->>> slot = QtCore.Slot(QtGui.QWidget, result=None)
+>>> from Qt import QtCore, QtWidgets
+>>> slot = QtCore.Slot(QtWidgets.QWidget, result=None)
 ```
 
 ```python
 # PyQt4, Python2
->>> from Qt import QtCore, QtGui
->>> slot = QtCore.Slot(QtGui.QWidget)
->>> slot = QtCore.Slot(QtGui.QWidget, result=None)
+>>> from Qt import QtCore, QtWidgets
+>>> slot = QtCore.Slot(QtWidgets.QWidget)
+>>> slot = QtCore.Slot(QtWidgets.QWidget, result=None)
 Traceback (most recent call last):
 ...
 TypeError: string or ASCII unicode expected not 'NoneType'
@@ -137,9 +137,9 @@ TypeError: string or ASCII unicode expected not 'NoneType'
 
 ```python
 # PyQt4, Python3
->>> from Qt import QtCore, QtGui
->>> slot = QtCore.Slot(QtGui.QWidget)
->>> slot = QtCore.Slot(QtGui.QWidget, result=None)
+>>> from Qt import QtCore, QtWidgets
+>>> slot = QtCore.Slot(QtWidgets.QWidget)
+>>> slot = QtCore.Slot(QtWidgets.QWidget, result=None)
 Traceback (most recent call last):
 ...
 TypeError: bytes or ASCII string expected not 'NoneType'
@@ -269,11 +269,11 @@ Or a conditional.
 
 ```python
 # PyQt5
->>> from Qt import QtWidgets, __binding__
+>>> from Qt import QtWidgets, QtCompat
 >>> app = QtWidgets.QApplication(sys.argv)
 >>> view = QtWidgets.QTreeWidget()
 >>> header = view.header()
->>> if __binding__ in ("PyQt4", "PySide"):
+>>> if QtCompat.__binding__ in ("PyQt4", "PySide"):
 ...   header.setResizeMode(QtWidgets.QHeaderView.Fixed)
 ... else:
 ...   header.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)

--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -8,6 +8,7 @@ There are cases where Qt.py is not handling incompatibility issues.
 - [QtWidgets.QAction.triggered](#qtwidgetsqactiontriggered)
 - [QtGui.QRegExpValidator](#qtguiqregexpvalidator)
 - [QtWidgets.QHeaderView.setResizeMode](#qtwidgetsqheaderviewsetresizemode)
+- [QtWidgets.qApp](#qtwidgetsqapp)
 
 <br>
 <br>
@@ -277,4 +278,39 @@ Or a conditional.
 ...   header.setResizeMode(QtWidgets.QHeaderView.Fixed)
 ... else:
 ...   header.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
+```
+
+
+#### QtWidgets.qApp
+
+In [Strict Mode](https://github.com/mottosso/Qt.py#qt_strict), `qApp` is not included in Qt.py due to the way Qt keeps this up to date with the currently active QApplication.
+
+Qt implicitly updates this variable through monkey patching whenever a new QApplication is instantiated. This means that our variable quickly goes out of date and is not updated at the same time.
+
+```python
+# PySide2
+>>> import os
+>>> os.environ["QT_STRICT"] = "1"
+>>> from Qt import QtWidgets
+>>> app = QtWidgets.QApplication(sys.argv)
+>>> QtWidgets.qApp
+Traceback (most recent call last):
+...
+AttributeError: 'module' object has no attribute 'qApp'
+```
+
+##### Workaround
+
+Use `QApplication.instance()` instead.
+
+Technically, there is no difference between the two, apart from more characters to type.
+
+```python
+# PySide2
+>>> import os
+>>> os.environ["QT_STRICT"] = "1"
+>>> from Qt import QtWidgets
+>>> app = QtWidgets.QApplication(sys.argv)
+>>> app == QtWidgets.QApplication.instance()
+True
 ```

--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -292,11 +292,8 @@ Qt implicitly updates this variable through monkey patching whenever a new QAppl
 >>> import os
 >>> os.environ["QT_STRICT"] = "1"
 >>> from Qt import QtWidgets
->>> app = QtWidgets.QApplication(sys.argv)
->>> QtWidgets.qApp
-Traceback (most recent call last):
-...
-AttributeError: 'module' object has no attribute 'qApp'
+>>> "qApp" in dir(QtWidgets)
+False
 ```
 
 ##### Workaround

--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -270,11 +270,11 @@ Or a conditional.
 
 ```python
 # PyQt5
->>> from Qt import QtWidgets, QtCompat
+>>> from Qt import QtWidgets, __binding__
 >>> app = QtWidgets.QApplication(sys.argv)
 >>> view = QtWidgets.QTreeWidget()
 >>> header = view.header()
->>> if QtCompat.__binding__ in ("PyQt4", "PySide"):
+>>> if __binding__ in ("PyQt4", "PySide"):
 ...   header.setResizeMode(QtWidgets.QHeaderView.Fixed)
 ... else:
 ...   header.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)

--- a/Qt.py
+++ b/Qt.py
@@ -62,6 +62,7 @@ import sys
 import types
 import shutil
 
+# Enable support for `from Qt import *`
 __all__ = [
     "QtGui",
     "QtCore",

--- a/Qt.py
+++ b/Qt.py
@@ -20,8 +20,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-
 Documentation
+
+    Map all bindings to PySide2
+
+    Project goals:
+        Qt.py was born in the film and visual effects industry to address
+        the growing need for the development of software capable of running
+        with more than one flavour of the Qt bindings for Python - PySide,
+        PySide2, PyQt4 and PyQt5.
+
+        1. Build for one, run with all
+        2. Explicit is better than implicit
+        3. Support co-existence
+
+    Default resolution order:
+        - PySide2
+        - PyQt5
+        - PySide
+        - PyQt4
+
+    Usage:
+        >> import sys
+        >> from Qt import QtWidgets
+        >> app = QtWidgets.QApplication(sys.argv)
+        >> button = QtWidgets.QPushButton("Hello World")
+        >> button.show()
+        >> app.exec_()
 
     All members of PySide2 are mapped from other bindings, should they exist.
     If no equivalent member exist, it is excluded from Qt.py and inaccessible.
@@ -37,66 +62,20 @@ import sys
 import types
 import shutil
 
+__all__ = ["QtGui", "QtCore", "QtWidgets", "QtCompat"]
+
 # Flags from environment variables
-QT_VERBOSE = bool(os.getenv("QT_VERBOSE"))                # Extra output
-QT_TESTING = bool(os.getenv("QT_TESTING"))                # Extra constraints
-QT_PREFERRED_BINDING = os.getenv("QT_PREFERRED_BINDING")  # Override default
+
+# Enable additional output when loading Qt.py
+QT_VERBOSE = bool(os.getenv("QT_VERBOSE"))
+QT_PREFERRED_BINDING = os.getenv("QT_PREFERRED_BINDING")
+QT_STRICT = bool(os.getenv("QT_STRICT"))
 
 # Supported submodules
-Qt = types.ModuleType("Qt")
 QtGui = types.ModuleType("QtGui")
 QtCore = types.ModuleType("QtCore")
 QtWidgets = types.ModuleType("QtWidgets")
 QtCompat = types.ModuleType("QtCompat")
-
-# Enable direct import of submodules
-# E.g. import Qt.QtCore
-sys.modules.update({
-    __name__ + ".QtGui": QtGui,
-    __name__ + ".QtCore": QtCore,
-    __name__ + ".QtWidgets": QtWidgets,
-    __name__ + ".QtCompat": QtCompat,
-})
-
-
-def _remap(object, name, value, safe=True):
-    """Prevent accidental assignment of existing members
-
-    Arguments:
-        object (object): Parent of new attribute
-        name (str): Name of new attribute
-        value (object): Value of new attribute
-        safe (bool): Whether or not to guarantee that
-            the new attribute was not overwritten.
-            Can be set to False under condition that
-            it is superseded by extensive testing.
-
-    """
-
-    if QT_TESTING and safe:
-        # Cannot alter original binding.
-        if hasattr(object, name):
-            raise AttributeError("Cannot override existing name: "
-                                 "%s.%s" % (object.__name__, name))
-
-        # Cannot alter classes of functions
-        if type(object).__name__ != "module":
-            raise AttributeError("%s != 'module': Cannot alter "
-                                 "anything but modules" % object)
-
-    elif hasattr(object, name):
-        # Keep track of modifications
-        QtCompat.__modified__.append(name)
-
-    QtCompat.__remapped__.append(name)
-
-    setattr(object, name, value)
-
-
-def _add(object, name, value):
-    """Append to self, accessible via Qt.QtCompat"""
-    QtCompat.__added__.append(name)
-    setattr(object, name, value)
 
 
 def _pyside2():
@@ -155,12 +134,12 @@ def _pyqt4():
         sip.setapi("QTextStream", 2)
         sip.setapi("QTime", 2)
         sip.setapi("QUrl", 2)
-    except AttributeError:
-        raise ImportError
+    except AttributeError as e:
+        raise ImportError(str(e))
         # PyQt4 < v4.6
-    except ValueError:
+    except ValueError as e:
         # API version already set to v1
-        raise ImportError
+        raise ImportError(str(e))
 
     from PyQt4 import QtGui, QtCore, uic
 
@@ -230,28 +209,28 @@ if QT_PREFERRED_BINDING:
     del(_preferred)
     del(_available)
 
-_log("Preferred binding: %s" % list(_b.__name__ for _b in _bindings))
+_log("Preferred bindings: %s" % list(_b.__name__ for _b in _bindings))
 
 
-_found_finding = False
+_found_binding = False
 for _binding in _bindings:
     _log("Trying %s" % _binding.__name__)
 
     try:
         _QtCore, _QtGui, _QtWidgets = _binding()
-        _found_finding = True
+        _found_binding = True
         break
 
     except ImportError as e:
-        _log("ImportError(\"%s\")" % e)
+        _log("ImportError: %s" % e)
         continue
 
-if not _found_finding:
+if not _found_binding:
     # If not binding were found, throw this error
     raise ImportError("No Qt binding were found.")
 
 
-def convert(lines):
+def _convert(lines):
     """Convert compiled .ui file from PySide2 to Qt.py
 
     Arguments:
@@ -259,7 +238,7 @@ def convert(lines):
 
     Usage:
         >> with open("myui.py") as f:
-        ..   lines = convert(f.readlines())
+        ..   lines = _convert(f.readlines())
 
     """
 
@@ -316,7 +295,7 @@ def _cli(args):
         # ------> Read
         #
         with open(args.convert) as f:
-            lines = convert(f.readlines())
+            lines = _convert(f.readlines())
 
         backup = "%s_backup%s" % os.path.splitext(args.convert)
         sys.stdout.write("Creating \"%s\"..\n" % backup)
@@ -331,505 +310,488 @@ def _cli(args):
         sys.stdout.write("Successfully converted \"%s\"\n" % args.convert)
 
 
-QtCompat.__added__ = list()     # All members added to QtCompat
-QtCompat.__remapped__ = list()  # Members copied from elsewhere
-QtCompat.__modified__ = list()  # Existing members modified in some way
+_members = {
+    "QtGui": [
+        "QAbstractTextDocumentLayout",
+        "QActionEvent",
+        "QBitmap",
+        "QBrush",
+        "QClipboard",
+        "QCloseEvent",
+        "QColor",
+        "QConicalGradient",
+        "QContextMenuEvent",
+        "QCursor",
+        "QDoubleValidator",
+        "QDrag",
+        "QDragEnterEvent",
+        "QDragLeaveEvent",
+        "QDragMoveEvent",
+        "QDropEvent",
+        "QFileOpenEvent",
+        "QFocusEvent",
+        "QFont",
+        "QFontDatabase",
+        "QFontInfo",
+        "QFontMetrics",
+        "QFontMetricsF",
+        "QGradient",
+        "QHelpEvent",
+        "QHideEvent",
+        "QHoverEvent",
+        "QIcon",
+        "QIconDragEvent",
+        "QIconEngine",
+        "QImage",
+        "QImageIOHandler",
+        "QImageReader",
+        "QImageWriter",
+        "QInputEvent",
+        "QInputMethodEvent",
+        "QIntValidator",
+        "QKeyEvent",
+        "QKeySequence",
+        "QLinearGradient",
+        "QMatrix2x2",
+        "QMatrix2x3",
+        "QMatrix2x4",
+        "QMatrix3x2",
+        "QMatrix3x3",
+        "QMatrix3x4",
+        "QMatrix4x2",
+        "QMatrix4x3",
+        "QMatrix4x4",
+        "QMouseEvent",
+        "QMoveEvent",
+        "QMovie",
+        "QPaintDevice",
+        "QPaintEngine",
+        "QPaintEngineState",
+        "QPaintEvent",
+        "QPainter",
+        "QPainterPath",
+        "QPainterPathStroker",
+        "QPalette",
+        "QPen",
+        "QPicture",
+        "QPictureIO",
+        "QPixmap",
+        "QPixmapCache",
+        "QPolygon",
+        "QPolygonF",
+        "QQuaternion",
+        "QRadialGradient",
+        "QRegExpValidator",
+        "QRegion",
+        "QResizeEvent",
+        "QSessionManager",
+        "QShortcutEvent",
+        "QShowEvent",
+        "QStandardItem",
+        "QStandardItemModel",
+        "QStatusTipEvent",
+        "QSyntaxHighlighter",
+        "QTabletEvent",
+        "QTextBlock",
+        "QTextBlockFormat",
+        "QTextBlockGroup",
+        "QTextBlockUserData",
+        "QTextCharFormat",
+        "QTextCursor",
+        "QTextDocument",
+        "QTextDocumentFragment",
+        "QTextFormat",
+        "QTextFragment",
+        "QTextFrame",
+        "QTextFrameFormat",
+        "QTextImageFormat",
+        "QTextInlineObject",
+        "QTextItem",
+        "QTextLayout",
+        "QTextLength",
+        "QTextLine",
+        "QTextList",
+        "QTextListFormat",
+        "QTextObject",
+        "QTextObjectInterface",
+        "QTextOption",
+        "QTextTable",
+        "QTextTableCell",
+        "QTextTableCellFormat",
+        "QTextTableFormat",
+        "QTransform",
+        "QValidator",
+        "QVector2D",
+        "QVector3D",
+        "QVector4D",
+        "QWhatsThisClickedEvent",
+        "QWheelEvent",
+        "QWindowStateChangeEvent",
+        "qAlpha",
+        "qBlue",
+        "qGray",
+        "qGreen",
+        "qIsGray",
+        "qRed",
+        "qRgb",
+        "qRgb",
+    ],
+    "QtWidgets": [
+        "QAbstractButton",
+        "QAbstractGraphicsShapeItem",
+        "QAbstractItemDelegate",
+        "QAbstractItemView",
+        "QAbstractScrollArea",
+        "QAbstractSlider",
+        "QAbstractSpinBox",
+        "QAction",
+        "QActionGroup",
+        "QApplication",
+        "QBoxLayout",
+        "QButtonGroup",
+        "QCalendarWidget",
+        "QCheckBox",
+        "QColorDialog",
+        "QColumnView",
+        "QComboBox",
+        "QCommandLinkButton",
+        "QCommonStyle",
+        "QCompleter",
+        "QDataWidgetMapper",
+        "QDateEdit",
+        "QDateTimeEdit",
+        "QDesktopWidget",
+        "QDial",
+        "QDialog",
+        "QDialogButtonBox",
+        "QDirModel",
+        "QDockWidget",
+        "QDoubleSpinBox",
+        "QErrorMessage",
+        "QFileDialog",
+        "QFileIconProvider",
+        "QFileSystemModel",
+        "QFocusFrame",
+        "QFontComboBox",
+        "QFontDialog",
+        "QFormLayout",
+        "QFrame",
+        "QGesture",
+        "QGestureEvent",
+        "QGestureRecognizer",
+        "QGraphicsAnchor",
+        "QGraphicsAnchorLayout",
+        "QGraphicsBlurEffect",
+        "QGraphicsColorizeEffect",
+        "QGraphicsDropShadowEffect",
+        "QGraphicsEffect",
+        "QGraphicsEllipseItem",
+        "QGraphicsGridLayout",
+        "QGraphicsItem",
+        # "QGraphicsItemAnimation",  # Not in PyQt4
+        "QGraphicsItemGroup",
+        "QGraphicsLayout",
+        "QGraphicsLayoutItem",
+        "QGraphicsLineItem",
+        "QGraphicsLinearLayout",
+        "QGraphicsObject",
+        "QGraphicsOpacityEffect",
+        "QGraphicsPathItem",
+        "QGraphicsPixmapItem",
+        "QGraphicsPolygonItem",
+        "QGraphicsProxyWidget",
+        "QGraphicsRectItem",
+        "QGraphicsRotation",
+        "QGraphicsScale",
+        "QGraphicsScene",
+        "QGraphicsSceneContextMenuEvent",
+        "QGraphicsSceneDragDropEvent",
+        "QGraphicsSceneEvent",
+        "QGraphicsSceneHelpEvent",
+        "QGraphicsSceneHoverEvent",
+        "QGraphicsSceneMouseEvent",
+        "QGraphicsSceneMoveEvent",
+        "QGraphicsSceneResizeEvent",
+        "QGraphicsSceneWheelEvent",
+        "QGraphicsSimpleTextItem",
+        "QGraphicsTextItem",
+        "QGraphicsTransform",
+        "QGraphicsView",
+        "QGraphicsWidget",
+        "QGridLayout",
+        "QGroupBox",
+        "QHBoxLayout",
+        "QHeaderView",
+        "QInputDialog",
+        "QItemDelegate",
+        "QItemEditorCreatorBase",
+        "QItemEditorFactory",
+        "QKeyEventTransition",
+        "QLCDNumber",
+        "QLabel",
+        "QLayout",
+        "QLayoutItem",
+        "QLineEdit",
+        "QListView",
+        "QListWidget",
+        "QListWidgetItem",
+        "QMainWindow",
+        "QMdiArea",
+        "QMdiSubWindow",
+        "QMenu",
+        "QMenuBar",
+        "QMessageBox",
+        "QMouseEventTransition",
+        "QPanGesture",
+        "QPinchGesture",
+        "QPlainTextDocumentLayout",
+        "QPlainTextEdit",
+        "QProgressBar",
+        "QProgressDialog",
+        "QPushButton",
+        "QRadioButton",
+        "QRubberBand",
+        "QScrollArea",
+        "QScrollBar",
+        "QShortcut",
+        "QSizeGrip",
+        "QSizePolicy",
+        "QSlider",
+        "QSpacerItem",
+        "QSpinBox",
+        "QSplashScreen",
+        "QSplitter",
+        "QSplitterHandle",
+        "QStackedLayout",
+        "QStackedWidget",
+        "QStatusBar",
+        "QStyle",
+        "QStyleFactory",
+        "QStyleHintReturn",
+        "QStyleHintReturnMask",
+        "QStyleHintReturnVariant",
+        "QStyleOption",
+        "QStyleOptionButton",
+        "QStyleOptionComboBox",
+        "QStyleOptionComplex",
+        "QStyleOptionDockWidget",
+        "QStyleOptionFocusRect",
+        "QStyleOptionFrame",
+        "QStyleOptionGraphicsItem",
+        "QStyleOptionGroupBox",
+        "QStyleOptionHeader",
+        "QStyleOptionMenuItem",
+        "QStyleOptionProgressBar",
+        "QStyleOptionRubberBand",
+        "QStyleOptionSizeGrip",
+        "QStyleOptionSlider",
+        "QStyleOptionSpinBox",
+        "QStyleOptionTab",
+        "QStyleOptionTabBarBase",
+        "QStyleOptionTabWidgetFrame",
+        "QStyleOptionTitleBar",
+        "QStyleOptionToolBar",
+        "QStyleOptionToolBox",
+        "QStyleOptionToolButton",
+        "QStyleOptionViewItem",
+        "QStylePainter",
+        "QStyledItemDelegate",
+        "QSwipeGesture",
+        "QSystemTrayIcon",
+        "QTabBar",
+        "QTabWidget",
+        "QTableView",
+        "QTableWidget",
+        "QTableWidgetItem",
+        "QTableWidgetSelectionRange",
+        "QTapAndHoldGesture",
+        "QTapGesture",
+        "QTextBrowser",
+        "QTextEdit",
+        "QTimeEdit",
+        "QToolBar",
+        "QToolBox",
+        "QToolButton",
+        "QToolTip",
+        "QTreeView",
+        "QTreeWidget",
+        "QTreeWidgetItem",
+        "QTreeWidgetItemIterator",
+        "QUndoCommand",
+        "QUndoGroup",
+        "QUndoStack",
+        "QUndoView",
+        "QVBoxLayout",
+        "QWhatsThis",
+        "QWidget",
+        "QWidgetAction",
+        "QWidgetItem",
+        "QWizard",
+        "QWizardPage",
+    ],
+
+    "QtCore": [
+        "QAbstractAnimation",
+        "QAbstractEventDispatcher",
+        "QAbstractItemModel",
+        "QAbstractListModel",
+        "QAbstractState",
+        "QAbstractTableModel",
+        "QAbstractTransition",
+        "QAnimationGroup",
+        "QBasicTimer",
+        "QBitArray",
+        "QBuffer",
+        "QByteArray",
+        "QByteArrayMatcher",
+        "QChildEvent",
+        "QCoreApplication",
+        "QCryptographicHash",
+        "QDataStream",
+        "QDate",
+        "QDateTime",
+        "QDir",
+        "QDirIterator",
+        "QDynamicPropertyChangeEvent",
+        "QEasingCurve",
+        "QElapsedTimer",
+        "QEvent",
+        "QEventLoop",
+        "QEventTransition",
+        "QFile",
+        "QFileInfo",
+        "QFileSystemWatcher",
+        "QFinalState",
+        "QGenericArgument",
+        "QGenericReturnArgument",
+        "QHistoryState",
+        "QIODevice",
+        "QLibraryInfo",
+        "QLine",
+        "QLineF",
+        "QLocale",
+        "QMargins",
+        "QMetaClassInfo",
+        "QMetaEnum",
+        "QMetaMethod",
+        "QMetaObject",
+        "QMetaProperty",
+        "QMimeData",
+        "QModelIndex",
+        "QMutex",
+        "QMutexLocker",
+        "QObject",
+        "QParallelAnimationGroup",
+        "QPauseAnimation",
+        "QPersistentModelIndex",
+        "QPluginLoader",
+        "QPoint",
+        "QPointF",
+        "QProcess",
+        "QProcessEnvironment",
+        "QPropertyAnimation",
+        "QReadLocker",
+        "QReadWriteLock",
+        "QRect",
+        "QRectF",
+        "QRegExp",
+        "QResource",
+        "QRunnable",
+        "QSemaphore",
+        "QSequentialAnimationGroup",
+        "QSettings",
+        "QSignalMapper",
+        "QSignalTransition",
+        "QSize",
+        "QSizeF",
+        "QSocketNotifier",
+        "QState",
+        "QStateMachine",
+        "QSysInfo",
+        "QSystemSemaphore",
+        "QTemporaryFile",
+        "QTextBoundaryFinder",
+        "QTextCodec",
+        "QTextDecoder",
+        "QTextEncoder",
+        "QTextStream",
+        "QTextStreamManipulator",
+        "QThread",
+        "QThreadPool",
+        "QTime",
+        "QTimeLine",
+        "QTimer",
+        "QTimerEvent",
+        "QTranslator",
+        "QUrl",
+        "QVariantAnimation",
+        "QWaitCondition",
+        "QWriteLocker",
+        "QXmlStreamAttribute",
+        "QXmlStreamAttributes",
+        "QXmlStreamEntityDeclaration",
+        "QXmlStreamEntityResolver",
+        "QXmlStreamNamespaceDeclaration",
+        "QXmlStreamNotationDeclaration",
+        "QXmlStreamReader",
+        "QXmlStreamWriter",
+        "Qt",
+        "QtCriticalMsg",
+        "QtDebugMsg",
+        "QtFatalMsg",
+        "QtMsgType",
+        "QtSystemMsg",
+        "QtWarningMsg",
+        "qAbs",
+        "qAddPostRoutine",
+        "qChecksum",
+        "qCritical",
+        "qDebug",
+        "qFatal",
+        "qFuzzyCompare",
+        "qIsFinite",
+        "qIsInf",
+        "qIsNaN",
+        "qIsNull",
+        "qRegisterResourceData",
+        "qUnregisterResourceData",
+        "qVersion",
+        "qWarning",
+        "qrand",
+        "qsrand",
+    ]
+}
+
 QtCompat.__version__ = "0.7.0"
-QtCompat._remap = _remap
-QtCompat._add = _add
-QtCompat.cli = _cli
+QtCompat._cli = _cli
+QtCompat._convert = _convert
 
-QtGui.QAbstractTextDocumentLayout = _QtGui.QAbstractTextDocumentLayout
-# QtGui.QAccessibleEvent = _QtGui.QAccessibleEvent  # Not in PyQt4
-QtGui.QActionEvent = _QtGui.QActionEvent
-QtGui.QBitmap = _QtGui.QBitmap
-QtGui.QBrush = _QtGui.QBrush
-QtGui.QClipboard = _QtGui.QClipboard
-QtGui.QCloseEvent = _QtGui.QCloseEvent
-QtGui.QColor = _QtGui.QColor
-QtGui.QConicalGradient = _QtGui.QConicalGradient
-QtGui.QContextMenuEvent = _QtGui.QContextMenuEvent
-QtGui.QCursor = _QtGui.QCursor
-QtGui.QDoubleValidator = _QtGui.QDoubleValidator
-QtGui.QDrag = _QtGui.QDrag
-QtGui.QDragEnterEvent = _QtGui.QDragEnterEvent
-QtGui.QDragLeaveEvent = _QtGui.QDragLeaveEvent
-QtGui.QDragMoveEvent = _QtGui.QDragMoveEvent
-QtGui.QDropEvent = _QtGui.QDropEvent
-QtGui.QFileOpenEvent = _QtGui.QFileOpenEvent
-QtGui.QFocusEvent = _QtGui.QFocusEvent
-QtGui.QFont = _QtGui.QFont
-QtGui.QFontDatabase = _QtGui.QFontDatabase
-QtGui.QFontInfo = _QtGui.QFontInfo
-QtGui.QFontMetrics = _QtGui.QFontMetrics
-QtGui.QFontMetricsF = _QtGui.QFontMetricsF
-QtGui.QGradient = _QtGui.QGradient
-# QtGui.QGuiApplication = _QtGui.QGuiApplication
-QtGui.QHelpEvent = _QtGui.QHelpEvent
-QtGui.QHideEvent = _QtGui.QHideEvent
-QtGui.QHoverEvent = _QtGui.QHoverEvent
-QtGui.QIcon = _QtGui.QIcon
-QtGui.QIconDragEvent = _QtGui.QIconDragEvent
-QtGui.QIconEngine = _QtGui.QIconEngine
-QtGui.QImage = _QtGui.QImage
-QtGui.QImageIOHandler = _QtGui.QImageIOHandler
-QtGui.QImageReader = _QtGui.QImageReader
-QtGui.QImageWriter = _QtGui.QImageWriter
-QtGui.QInputEvent = _QtGui.QInputEvent
-QtGui.QInputMethodEvent = _QtGui.QInputMethodEvent
-QtGui.QIntValidator = _QtGui.QIntValidator
-QtGui.QKeyEvent = _QtGui.QKeyEvent
-QtGui.QKeySequence = _QtGui.QKeySequence
-QtGui.QLinearGradient = _QtGui.QLinearGradient
-# QtGui.QMatrix = _QtGui.QMatrix  # Not in PyQt5
-QtGui.QMatrix2x2 = _QtGui.QMatrix2x2
-QtGui.QMatrix2x3 = _QtGui.QMatrix2x3
-QtGui.QMatrix2x4 = _QtGui.QMatrix2x4
-QtGui.QMatrix3x2 = _QtGui.QMatrix3x2
-QtGui.QMatrix3x3 = _QtGui.QMatrix3x3
-QtGui.QMatrix3x4 = _QtGui.QMatrix3x4
-QtGui.QMatrix4x2 = _QtGui.QMatrix4x2
-QtGui.QMatrix4x3 = _QtGui.QMatrix4x3
-QtGui.QMatrix4x4 = _QtGui.QMatrix4x4
-QtGui.QMouseEvent = _QtGui.QMouseEvent
-QtGui.QMoveEvent = _QtGui.QMoveEvent
-QtGui.QMovie = _QtGui.QMovie
-# QtGui.QPagedPaintDevice = _QtGui.QPagedPaintDevice
-QtGui.QPaintDevice = _QtGui.QPaintDevice
-QtGui.QPaintEngine = _QtGui.QPaintEngine
-QtGui.QPaintEngineState = _QtGui.QPaintEngineState
-QtGui.QPaintEvent = _QtGui.QPaintEvent
-QtGui.QPainter = _QtGui.QPainter
-QtGui.QPainterPath = _QtGui.QPainterPath
-QtGui.QPainterPathStroker = _QtGui.QPainterPathStroker
-QtGui.QPalette = _QtGui.QPalette
-QtGui.QPen = _QtGui.QPen
-QtGui.QPicture = _QtGui.QPicture
-QtGui.QPictureIO = _QtGui.QPictureIO
-QtGui.QPixmap = _QtGui.QPixmap
-QtGui.QPixmapCache = _QtGui.QPixmapCache
-QtGui.QPolygon = _QtGui.QPolygon
-QtGui.QPolygonF = _QtGui.QPolygonF
-# QtGui.QPyTextObject = _QtGui.QPyTextObject  # Not in PyQt5
-QtGui.QQuaternion = _QtGui.QQuaternion
-QtGui.QRadialGradient = _QtGui.QRadialGradient
-QtGui.QRegExpValidator = _QtGui.QRegExpValidator
-QtGui.QRegion = _QtGui.QRegion
-QtGui.QResizeEvent = _QtGui.QResizeEvent
-QtGui.QSessionManager = _QtGui.QSessionManager
-QtGui.QShortcutEvent = _QtGui.QShortcutEvent
-QtGui.QShowEvent = _QtGui.QShowEvent
-QtGui.QStandardItem = _QtGui.QStandardItem
-QtGui.QStandardItemModel = _QtGui.QStandardItemModel
-QtGui.QStatusTipEvent = _QtGui.QStatusTipEvent
-# QtGui.QSurface = _QtGui.QSurface
-# QtGui.QSurfaceFormat = _QtGui.QSurfaceFormat
-QtGui.QSyntaxHighlighter = _QtGui.QSyntaxHighlighter
-QtGui.QTabletEvent = _QtGui.QTabletEvent
-QtGui.QTextBlock = _QtGui.QTextBlock
-QtGui.QTextBlockFormat = _QtGui.QTextBlockFormat
-QtGui.QTextBlockGroup = _QtGui.QTextBlockGroup
-QtGui.QTextBlockUserData = _QtGui.QTextBlockUserData
-QtGui.QTextCharFormat = _QtGui.QTextCharFormat
-QtGui.QTextCursor = _QtGui.QTextCursor
-QtGui.QTextDocument = _QtGui.QTextDocument
-QtGui.QTextDocumentFragment = _QtGui.QTextDocumentFragment
-QtGui.QTextFormat = _QtGui.QTextFormat
-QtGui.QTextFragment = _QtGui.QTextFragment
-QtGui.QTextFrame = _QtGui.QTextFrame
-QtGui.QTextFrameFormat = _QtGui.QTextFrameFormat
-QtGui.QTextImageFormat = _QtGui.QTextImageFormat
-QtGui.QTextInlineObject = _QtGui.QTextInlineObject
-QtGui.QTextItem = _QtGui.QTextItem
-QtGui.QTextLayout = _QtGui.QTextLayout
-QtGui.QTextLength = _QtGui.QTextLength
-QtGui.QTextLine = _QtGui.QTextLine
-QtGui.QTextList = _QtGui.QTextList
-QtGui.QTextListFormat = _QtGui.QTextListFormat
-QtGui.QTextObject = _QtGui.QTextObject
-QtGui.QTextObjectInterface = _QtGui.QTextObjectInterface
-QtGui.QTextOption = _QtGui.QTextOption
-QtGui.QTextTable = _QtGui.QTextTable
-QtGui.QTextTableCell = _QtGui.QTextTableCell
-QtGui.QTextTableCellFormat = _QtGui.QTextTableCellFormat
-QtGui.QTextTableFormat = _QtGui.QTextTableFormat
-# QtGui.QToolBarChangeEvent = _QtGui.QToolBarChangeEvent  # Not in PyQt4
-# QtGui.QTouchDevice = _QtGui.QTouchDevice
-# QtGui.QTouchEvent = _QtGui.QTouchEvent
-QtGui.QTransform = _QtGui.QTransform
-QtGui.QValidator = _QtGui.QValidator
-QtGui.QVector2D = _QtGui.QVector2D
-QtGui.QVector3D = _QtGui.QVector3D
-QtGui.QVector4D = _QtGui.QVector4D
-QtGui.QWhatsThisClickedEvent = _QtGui.QWhatsThisClickedEvent
-QtGui.QWheelEvent = _QtGui.QWheelEvent
-# QtGui.QWindow = _QtGui.QWindow
-QtGui.QWindowStateChangeEvent = _QtGui.QWindowStateChangeEvent
-QtGui.qAlpha = _QtGui.qAlpha
-QtGui.qBlue = _QtGui.qBlue
-QtGui.qGray = _QtGui.qGray
-QtGui.qGreen = _QtGui.qGreen
-QtGui.qIsGray = _QtGui.qIsGray
-QtGui.qRed = _QtGui.qRed
-QtGui.qRgb = _QtGui.qRgb
-QtGui.qRgb = _QtGui.qRgb
+QtCompat.__added__ = list()     # DEPRECATED
+QtCompat.__remapped__ = list()  # DEPRECATED
+QtCompat.__modified__ = list()  # DEPRECATED
+QtCompat.__wrapper_version__ = "0.7.0"  # DEPRECATED
 
+if QT_STRICT:
+    for _module, _members in _members.items():
+        for _member in _members:
+            _original = getattr(sys.modules[__name__], "_%s" % _module)
+            _replacement = getattr(sys.modules[__name__], _module)
+            setattr(_replacement, _member, getattr(_original, _member))
 
-QtWidgets.QAbstractButton = _QtWidgets.QAbstractButton
-QtWidgets.QAbstractGraphicsShapeItem = _QtWidgets.QAbstractGraphicsShapeItem
-QtWidgets.QAbstractItemDelegate = _QtWidgets.QAbstractItemDelegate
-QtWidgets.QAbstractItemView = _QtWidgets.QAbstractItemView
-QtWidgets.QAbstractScrollArea = _QtWidgets.QAbstractScrollArea
-QtWidgets.QAbstractSlider = _QtWidgets.QAbstractSlider
-QtWidgets.QAbstractSpinBox = _QtWidgets.QAbstractSpinBox
-QtWidgets.QAction = _QtWidgets.QAction
-QtWidgets.QActionGroup = _QtWidgets.QActionGroup
-QtWidgets.QApplication = _QtWidgets.QApplication
-QtWidgets.QBoxLayout = _QtWidgets.QBoxLayout
-QtWidgets.QButtonGroup = _QtWidgets.QButtonGroup
-QtWidgets.QCalendarWidget = _QtWidgets.QCalendarWidget
-QtWidgets.QCheckBox = _QtWidgets.QCheckBox
-QtWidgets.QColorDialog = _QtWidgets.QColorDialog
-QtWidgets.QColumnView = _QtWidgets.QColumnView
-QtWidgets.QComboBox = _QtWidgets.QComboBox
-QtWidgets.QCommandLinkButton = _QtWidgets.QCommandLinkButton
-QtWidgets.QCommonStyle = _QtWidgets.QCommonStyle
-QtWidgets.QCompleter = _QtWidgets.QCompleter
-QtWidgets.QDataWidgetMapper = _QtWidgets.QDataWidgetMapper
-QtWidgets.QDateEdit = _QtWidgets.QDateEdit
-QtWidgets.QDateTimeEdit = _QtWidgets.QDateTimeEdit
-QtWidgets.QDesktopWidget = _QtWidgets.QDesktopWidget
-QtWidgets.QDial = _QtWidgets.QDial
-QtWidgets.QDialog = _QtWidgets.QDialog
-QtWidgets.QDialogButtonBox = _QtWidgets.QDialogButtonBox
-QtWidgets.QDirModel = _QtWidgets.QDirModel
-QtWidgets.QDockWidget = _QtWidgets.QDockWidget
-QtWidgets.QDoubleSpinBox = _QtWidgets.QDoubleSpinBox
-QtWidgets.QErrorMessage = _QtWidgets.QErrorMessage
-QtWidgets.QFileDialog = _QtWidgets.QFileDialog
-QtWidgets.QFileIconProvider = _QtWidgets.QFileIconProvider
-QtWidgets.QFileSystemModel = _QtWidgets.QFileSystemModel
-QtWidgets.QFocusFrame = _QtWidgets.QFocusFrame
-QtWidgets.QFontComboBox = _QtWidgets.QFontComboBox
-QtWidgets.QFontDialog = _QtWidgets.QFontDialog
-QtWidgets.QFormLayout = _QtWidgets.QFormLayout
-QtWidgets.QFrame = _QtWidgets.QFrame
-QtWidgets.QGesture = _QtWidgets.QGesture
-QtWidgets.QGestureEvent = _QtWidgets.QGestureEvent
-QtWidgets.QGestureRecognizer = _QtWidgets.QGestureRecognizer
-QtWidgets.QGraphicsAnchor = _QtWidgets.QGraphicsAnchor
-QtWidgets.QGraphicsAnchorLayout = _QtWidgets.QGraphicsAnchorLayout
-QtWidgets.QGraphicsBlurEffect = _QtWidgets.QGraphicsBlurEffect
-QtWidgets.QGraphicsColorizeEffect = _QtWidgets.QGraphicsColorizeEffect
-QtWidgets.QGraphicsDropShadowEffect = _QtWidgets.QGraphicsDropShadowEffect
-QtWidgets.QGraphicsEffect = _QtWidgets.QGraphicsEffect
-QtWidgets.QGraphicsEllipseItem = _QtWidgets.QGraphicsEllipseItem
-QtWidgets.QGraphicsGridLayout = _QtWidgets.QGraphicsGridLayout
-QtWidgets.QGraphicsItem = _QtWidgets.QGraphicsItem
-# QtWidgets.QGraphicsItemAnimation = _QtWidgets.QGraphicsItemAnimation  # Not in PyQt4
-QtWidgets.QGraphicsItemGroup = _QtWidgets.QGraphicsItemGroup
-QtWidgets.QGraphicsLayout = _QtWidgets.QGraphicsLayout
-QtWidgets.QGraphicsLayoutItem = _QtWidgets.QGraphicsLayoutItem
-QtWidgets.QGraphicsLineItem = _QtWidgets.QGraphicsLineItem
-QtWidgets.QGraphicsLinearLayout = _QtWidgets.QGraphicsLinearLayout
-QtWidgets.QGraphicsObject = _QtWidgets.QGraphicsObject
-QtWidgets.QGraphicsOpacityEffect = _QtWidgets.QGraphicsOpacityEffect
-QtWidgets.QGraphicsPathItem = _QtWidgets.QGraphicsPathItem
-QtWidgets.QGraphicsPixmapItem = _QtWidgets.QGraphicsPixmapItem
-QtWidgets.QGraphicsPolygonItem = _QtWidgets.QGraphicsPolygonItem
-QtWidgets.QGraphicsProxyWidget = _QtWidgets.QGraphicsProxyWidget
-QtWidgets.QGraphicsRectItem = _QtWidgets.QGraphicsRectItem
-QtWidgets.QGraphicsRotation = _QtWidgets.QGraphicsRotation
-QtWidgets.QGraphicsScale = _QtWidgets.QGraphicsScale
-QtWidgets.QGraphicsScene = _QtWidgets.QGraphicsScene
-QtWidgets.QGraphicsSceneContextMenuEvent = _QtWidgets.QGraphicsSceneContextMenuEvent
-QtWidgets.QGraphicsSceneDragDropEvent = _QtWidgets.QGraphicsSceneDragDropEvent
-QtWidgets.QGraphicsSceneEvent = _QtWidgets.QGraphicsSceneEvent
-QtWidgets.QGraphicsSceneHelpEvent = _QtWidgets.QGraphicsSceneHelpEvent
-QtWidgets.QGraphicsSceneHoverEvent = _QtWidgets.QGraphicsSceneHoverEvent
-QtWidgets.QGraphicsSceneMouseEvent = _QtWidgets.QGraphicsSceneMouseEvent
-QtWidgets.QGraphicsSceneMoveEvent = _QtWidgets.QGraphicsSceneMoveEvent
-QtWidgets.QGraphicsSceneResizeEvent = _QtWidgets.QGraphicsSceneResizeEvent
-QtWidgets.QGraphicsSceneWheelEvent = _QtWidgets.QGraphicsSceneWheelEvent
-QtWidgets.QGraphicsSimpleTextItem = _QtWidgets.QGraphicsSimpleTextItem
-QtWidgets.QGraphicsTextItem = _QtWidgets.QGraphicsTextItem
-QtWidgets.QGraphicsTransform = _QtWidgets.QGraphicsTransform
-QtWidgets.QGraphicsView = _QtWidgets.QGraphicsView
-QtWidgets.QGraphicsWidget = _QtWidgets.QGraphicsWidget
-QtWidgets.QGridLayout = _QtWidgets.QGridLayout
-QtWidgets.QGroupBox = _QtWidgets.QGroupBox
-QtWidgets.QHBoxLayout = _QtWidgets.QHBoxLayout
-QtWidgets.QHeaderView = _QtWidgets.QHeaderView
-QtWidgets.QInputDialog = _QtWidgets.QInputDialog
-QtWidgets.QItemDelegate = _QtWidgets.QItemDelegate
-QtWidgets.QItemEditorCreatorBase = _QtWidgets.QItemEditorCreatorBase
-QtWidgets.QItemEditorFactory = _QtWidgets.QItemEditorFactory
-QtWidgets.QKeyEventTransition = _QtWidgets.QKeyEventTransition
-QtWidgets.QLCDNumber = _QtWidgets.QLCDNumber
-QtWidgets.QLabel = _QtWidgets.QLabel
-QtWidgets.QLayout = _QtWidgets.QLayout
-QtWidgets.QLayoutItem = _QtWidgets.QLayoutItem
-QtWidgets.QLineEdit = _QtWidgets.QLineEdit
-QtWidgets.QListView = _QtWidgets.QListView
-QtWidgets.QListWidget = _QtWidgets.QListWidget
-QtWidgets.QListWidgetItem = _QtWidgets.QListWidgetItem
-QtWidgets.QMainWindow = _QtWidgets.QMainWindow
-QtWidgets.QMdiArea = _QtWidgets.QMdiArea
-QtWidgets.QMdiSubWindow = _QtWidgets.QMdiSubWindow
-QtWidgets.QMenu = _QtWidgets.QMenu
-QtWidgets.QMenuBar = _QtWidgets.QMenuBar
-QtWidgets.QMessageBox = _QtWidgets.QMessageBox
-QtWidgets.QMouseEventTransition = _QtWidgets.QMouseEventTransition
-QtWidgets.QPanGesture = _QtWidgets.QPanGesture
-QtWidgets.QPinchGesture = _QtWidgets.QPinchGesture
-QtWidgets.QPlainTextDocumentLayout = _QtWidgets.QPlainTextDocumentLayout
-QtWidgets.QPlainTextEdit = _QtWidgets.QPlainTextEdit
-QtWidgets.QProgressBar = _QtWidgets.QProgressBar
-QtWidgets.QProgressDialog = _QtWidgets.QProgressDialog
-QtWidgets.QPushButton = _QtWidgets.QPushButton
-QtWidgets.QRadioButton = _QtWidgets.QRadioButton
-QtWidgets.QRubberBand = _QtWidgets.QRubberBand
-QtWidgets.QScrollArea = _QtWidgets.QScrollArea
-QtWidgets.QScrollBar = _QtWidgets.QScrollBar
-QtWidgets.QShortcut = _QtWidgets.QShortcut
-QtWidgets.QSizeGrip = _QtWidgets.QSizeGrip
-QtWidgets.QSizePolicy = _QtWidgets.QSizePolicy
-QtWidgets.QSlider = _QtWidgets.QSlider
-QtWidgets.QSpacerItem = _QtWidgets.QSpacerItem
-QtWidgets.QSpinBox = _QtWidgets.QSpinBox
-QtWidgets.QSplashScreen = _QtWidgets.QSplashScreen
-QtWidgets.QSplitter = _QtWidgets.QSplitter
-QtWidgets.QSplitterHandle = _QtWidgets.QSplitterHandle
-QtWidgets.QStackedLayout = _QtWidgets.QStackedLayout
-QtWidgets.QStackedWidget = _QtWidgets.QStackedWidget
-QtWidgets.QStatusBar = _QtWidgets.QStatusBar
-QtWidgets.QStyle = _QtWidgets.QStyle
-QtWidgets.QStyleFactory = _QtWidgets.QStyleFactory
-QtWidgets.QStyleHintReturn = _QtWidgets.QStyleHintReturn
-QtWidgets.QStyleHintReturnMask = _QtWidgets.QStyleHintReturnMask
-QtWidgets.QStyleHintReturnVariant = _QtWidgets.QStyleHintReturnVariant
-QtWidgets.QStyleOption = _QtWidgets.QStyleOption
-QtWidgets.QStyleOptionButton = _QtWidgets.QStyleOptionButton
-QtWidgets.QStyleOptionComboBox = _QtWidgets.QStyleOptionComboBox
-QtWidgets.QStyleOptionComplex = _QtWidgets.QStyleOptionComplex
-QtWidgets.QStyleOptionDockWidget = _QtWidgets.QStyleOptionDockWidget
-QtWidgets.QStyleOptionFocusRect = _QtWidgets.QStyleOptionFocusRect
-QtWidgets.QStyleOptionFrame = _QtWidgets.QStyleOptionFrame
-QtWidgets.QStyleOptionGraphicsItem = _QtWidgets.QStyleOptionGraphicsItem
-QtWidgets.QStyleOptionGroupBox = _QtWidgets.QStyleOptionGroupBox
-QtWidgets.QStyleOptionHeader = _QtWidgets.QStyleOptionHeader
-QtWidgets.QStyleOptionMenuItem = _QtWidgets.QStyleOptionMenuItem
-QtWidgets.QStyleOptionProgressBar = _QtWidgets.QStyleOptionProgressBar
-QtWidgets.QStyleOptionRubberBand = _QtWidgets.QStyleOptionRubberBand
-QtWidgets.QStyleOptionSizeGrip = _QtWidgets.QStyleOptionSizeGrip
-QtWidgets.QStyleOptionSlider = _QtWidgets.QStyleOptionSlider
-QtWidgets.QStyleOptionSpinBox = _QtWidgets.QStyleOptionSpinBox
-QtWidgets.QStyleOptionTab = _QtWidgets.QStyleOptionTab
-QtWidgets.QStyleOptionTabBarBase = _QtWidgets.QStyleOptionTabBarBase
-QtWidgets.QStyleOptionTabWidgetFrame = _QtWidgets.QStyleOptionTabWidgetFrame
-QtWidgets.QStyleOptionTitleBar = _QtWidgets.QStyleOptionTitleBar
-QtWidgets.QStyleOptionToolBar = _QtWidgets.QStyleOptionToolBar
-QtWidgets.QStyleOptionToolBox = _QtWidgets.QStyleOptionToolBox
-QtWidgets.QStyleOptionToolButton = _QtWidgets.QStyleOptionToolButton
-QtWidgets.QStyleOptionViewItem = _QtWidgets.QStyleOptionViewItem
-QtWidgets.QStylePainter = _QtWidgets.QStylePainter
-QtWidgets.QStyledItemDelegate = _QtWidgets.QStyledItemDelegate
-QtWidgets.QSwipeGesture = _QtWidgets.QSwipeGesture
-QtWidgets.QSystemTrayIcon = _QtWidgets.QSystemTrayIcon
-QtWidgets.QTabBar = _QtWidgets.QTabBar
-QtWidgets.QTabWidget = _QtWidgets.QTabWidget
-QtWidgets.QTableView = _QtWidgets.QTableView
-QtWidgets.QTableWidget = _QtWidgets.QTableWidget
-QtWidgets.QTableWidgetItem = _QtWidgets.QTableWidgetItem
-QtWidgets.QTableWidgetSelectionRange = _QtWidgets.QTableWidgetSelectionRange
-QtWidgets.QTapAndHoldGesture = _QtWidgets.QTapAndHoldGesture
-QtWidgets.QTapGesture = _QtWidgets.QTapGesture
-QtWidgets.QTextBrowser = _QtWidgets.QTextBrowser
-QtWidgets.QTextEdit = _QtWidgets.QTextEdit
-# QtWidgets.QTileRules = _QtWidgets.QTileRules  # Not in PyQt4
-QtWidgets.QTimeEdit = _QtWidgets.QTimeEdit
-QtWidgets.QToolBar = _QtWidgets.QToolBar
-QtWidgets.QToolBox = _QtWidgets.QToolBox
-QtWidgets.QToolButton = _QtWidgets.QToolButton
-QtWidgets.QToolTip = _QtWidgets.QToolTip
-QtWidgets.QTreeView = _QtWidgets.QTreeView
-QtWidgets.QTreeWidget = _QtWidgets.QTreeWidget
-QtWidgets.QTreeWidgetItem = _QtWidgets.QTreeWidgetItem
-QtWidgets.QTreeWidgetItemIterator = _QtWidgets.QTreeWidgetItemIterator
-QtWidgets.QUndoCommand = _QtWidgets.QUndoCommand
-QtWidgets.QUndoGroup = _QtWidgets.QUndoGroup
-QtWidgets.QUndoStack = _QtWidgets.QUndoStack
-QtWidgets.QUndoView = _QtWidgets.QUndoView
-QtWidgets.QVBoxLayout = _QtWidgets.QVBoxLayout
-QtWidgets.QWhatsThis = _QtWidgets.QWhatsThis
-QtWidgets.QWidget = _QtWidgets.QWidget
-QtWidgets.QWidgetAction = _QtWidgets.QWidgetAction
-QtWidgets.QWidgetItem = _QtWidgets.QWidgetItem
-QtWidgets.QWizard = _QtWidgets.QWizard
-QtWidgets.QWizardPage = _QtWidgets.QWizardPage
-QtWidgets.qApp = _QtWidgets.qApp
+else:
+    # Plain reference to original modules
+    QtWidgets = _QtWidgets
+    QtGui = _QtGui
+    QtCore = _QtCore
 
-
-# QtCore.ClassInfo = _QtCore.ClassInfo  # Not in PyQt4
-# QtCore.Connection = _QtCore.Connection  # Not in docs?
-# QtCore.MetaFunction = _QtCore.MetaFunction  # Not in PyQt4
-QtCore.QAbstractAnimation = _QtCore.QAbstractAnimation
-QtCore.QAbstractEventDispatcher = _QtCore.QAbstractEventDispatcher
-QtCore.QAbstractItemModel = _QtCore.QAbstractItemModel
-QtCore.QAbstractListModel = _QtCore.QAbstractListModel
-QtCore.QAbstractState = _QtCore.QAbstractState
-QtCore.QAbstractTableModel = _QtCore.QAbstractTableModel
-QtCore.QAbstractTransition = _QtCore.QAbstractTransition
-QtCore.QAnimationGroup = _QtCore.QAnimationGroup
-# QtCore.QBasicMutex = _QtCore.QBasicMutex  # Not in docs?
-QtCore.QBasicTimer = _QtCore.QBasicTimer
-QtCore.QBitArray = _QtCore.QBitArray
-QtCore.QBuffer = _QtCore.QBuffer
-QtCore.QByteArray = _QtCore.QByteArray
-QtCore.QByteArrayMatcher = _QtCore.QByteArrayMatcher
-QtCore.QChildEvent = _QtCore.QChildEvent
-QtCore.QCoreApplication = _QtCore.QCoreApplication
-QtCore.QCryptographicHash = _QtCore.QCryptographicHash
-QtCore.QDataStream = _QtCore.QDataStream
-QtCore.QDate = _QtCore.QDate
-QtCore.QDateTime = _QtCore.QDateTime
-QtCore.QDir = _QtCore.QDir
-QtCore.QDirIterator = _QtCore.QDirIterator
-QtCore.QDynamicPropertyChangeEvent = _QtCore.QDynamicPropertyChangeEvent
-QtCore.QEasingCurve = _QtCore.QEasingCurve
-QtCore.QElapsedTimer = _QtCore.QElapsedTimer
-QtCore.QEvent = _QtCore.QEvent
-QtCore.QEventLoop = _QtCore.QEventLoop
-QtCore.QEventTransition = _QtCore.QEventTransition
-# QtCore.QFactoryInterface = _QtCore.QFactoryInterface  # Not in PyQt4
-QtCore.QFile = _QtCore.QFile
-# QtCore.QFileDevice = _QtCore.QFileDevice
-QtCore.QFileInfo = _QtCore.QFileInfo
-QtCore.QFileSystemWatcher = _QtCore.QFileSystemWatcher
-QtCore.QFinalState = _QtCore.QFinalState
-QtCore.QGenericArgument = _QtCore.QGenericArgument
-QtCore.QGenericReturnArgument = _QtCore.QGenericReturnArgument
-QtCore.QHistoryState = _QtCore.QHistoryState
-QtCore.QIODevice = _QtCore.QIODevice
-# QtCore.QItemSelectionRange = _QtCore.QItemSelectionRange
-# QtCore.QJsonArray = _QtCore.QJsonArray
-# QtCore.QJsonDocument = _QtCore.QJsonDocument
-# QtCore.QJsonParseError = _QtCore.QJsonParseError
-# QtCore.QJsonValue = _QtCore.QJsonValue
-QtCore.QLibraryInfo = _QtCore.QLibraryInfo
-QtCore.QLine = _QtCore.QLine
-QtCore.QLineF = _QtCore.QLineF
-QtCore.QLocale = _QtCore.QLocale
-QtCore.QMargins = _QtCore.QMargins
-# QtCore.QMessageLogContext = _QtCore.QMessageLogContext
-QtCore.QMetaClassInfo = _QtCore.QMetaClassInfo
-QtCore.QMetaEnum = _QtCore.QMetaEnum
-QtCore.QMetaMethod = _QtCore.QMetaMethod
-QtCore.QMetaObject = _QtCore.QMetaObject
-QtCore.QMetaProperty = _QtCore.QMetaProperty
-QtCore.QMimeData = _QtCore.QMimeData
-QtCore.QModelIndex = _QtCore.QModelIndex
-QtCore.QMutex = _QtCore.QMutex
-QtCore.QMutexLocker = _QtCore.QMutexLocker
-QtCore.QObject = _QtCore.QObject
-QtCore.QParallelAnimationGroup = _QtCore.QParallelAnimationGroup
-QtCore.QPauseAnimation = _QtCore.QPauseAnimation
-QtCore.QPersistentModelIndex = _QtCore.QPersistentModelIndex
-QtCore.QPluginLoader = _QtCore.QPluginLoader
-QtCore.QPoint = _QtCore.QPoint
-QtCore.QPointF = _QtCore.QPointF
-QtCore.QProcess = _QtCore.QProcess
-QtCore.QProcessEnvironment = _QtCore.QProcessEnvironment
-QtCore.QPropertyAnimation = _QtCore.QPropertyAnimation
-QtCore.QReadLocker = _QtCore.QReadLocker
-QtCore.QReadWriteLock = _QtCore.QReadWriteLock
-QtCore.QRect = _QtCore.QRect
-QtCore.QRectF = _QtCore.QRectF
-QtCore.QRegExp = _QtCore.QRegExp
-QtCore.QResource = _QtCore.QResource
-QtCore.QRunnable = _QtCore.QRunnable
-QtCore.QSemaphore = _QtCore.QSemaphore
-QtCore.QSequentialAnimationGroup = _QtCore.QSequentialAnimationGroup
-QtCore.QSettings = _QtCore.QSettings
-QtCore.QSignalMapper = _QtCore.QSignalMapper
-QtCore.QSignalTransition = _QtCore.QSignalTransition
-QtCore.QSize = _QtCore.QSize
-QtCore.QSizeF = _QtCore.QSizeF
-QtCore.QSocketNotifier = _QtCore.QSocketNotifier
-QtCore.QState = _QtCore.QState
-QtCore.QStateMachine = _QtCore.QStateMachine
-QtCore.QSysInfo = _QtCore.QSysInfo
-QtCore.QSystemSemaphore = _QtCore.QSystemSemaphore
-# QtCore.QT_TRANSLATE_NOOP = _QtCore.QT_TRANSLATE_NOOP  # Not in PyQt4
-# QtCore.QT_TRANSLATE_NOOP3 = _QtCore.QT_TRANSLATE_NOOP3  # Not in PyQt4
-# QtCore.QT_TRANSLATE_NOOP_UTF8 = _QtCore.QT_TRANSLATE_NOOP_UTF8  # Not in PyQt4
-# QtCore.QT_TR_NOOP = _QtCore.QT_TR_NOOP  # Not in PyQt4
-# QtCore.QT_TR_NOOP_UTF8 = _QtCore.QT_TR_NOOP_UTF8  # Not in PyQt4
-QtCore.QTemporaryFile = _QtCore.QTemporaryFile
-QtCore.QTextBoundaryFinder = _QtCore.QTextBoundaryFinder
-QtCore.QTextCodec = _QtCore.QTextCodec
-QtCore.QTextDecoder = _QtCore.QTextDecoder
-QtCore.QTextEncoder = _QtCore.QTextEncoder
-QtCore.QTextStream = _QtCore.QTextStream
-QtCore.QTextStreamManipulator = _QtCore.QTextStreamManipulator
-QtCore.QThread = _QtCore.QThread
-QtCore.QThreadPool = _QtCore.QThreadPool
-QtCore.QTime = _QtCore.QTime
-QtCore.QTimeLine = _QtCore.QTimeLine
-QtCore.QTimer = _QtCore.QTimer
-QtCore.QTimerEvent = _QtCore.QTimerEvent
-QtCore.QTranslator = _QtCore.QTranslator
-QtCore.QUrl = _QtCore.QUrl
-QtCore.QVariantAnimation = _QtCore.QVariantAnimation
-QtCore.QWaitCondition = _QtCore.QWaitCondition
-QtCore.QWriteLocker = _QtCore.QWriteLocker
-QtCore.QXmlStreamAttribute = _QtCore.QXmlStreamAttribute
-QtCore.QXmlStreamAttributes = _QtCore.QXmlStreamAttributes
-QtCore.QXmlStreamEntityDeclaration = _QtCore.QXmlStreamEntityDeclaration
-QtCore.QXmlStreamEntityResolver = _QtCore.QXmlStreamEntityResolver
-QtCore.QXmlStreamNamespaceDeclaration = _QtCore.QXmlStreamNamespaceDeclaration
-QtCore.QXmlStreamNotationDeclaration = _QtCore.QXmlStreamNotationDeclaration
-QtCore.QXmlStreamReader = _QtCore.QXmlStreamReader
-QtCore.QXmlStreamWriter = _QtCore.QXmlStreamWriter
-QtCore.Qt = _QtCore.Qt
-QtCore.QtCriticalMsg = _QtCore.QtCriticalMsg
-QtCore.QtDebugMsg = _QtCore.QtDebugMsg
-QtCore.QtFatalMsg = _QtCore.QtFatalMsg
-# QtCore.QtInfoMsg = _QtCore.QtInfoMsg  # Not in docs?
-QtCore.QtMsgType = _QtCore.QtMsgType
-QtCore.QtSystemMsg = _QtCore.QtSystemMsg
-QtCore.QtWarningMsg = _QtCore.QtWarningMsg
-# QtCore.SIGNAL = _QtCore.SIGNAL  # Not in PyQt5
-# QtCore.SLOT = _QtCore.SLOT  # Not in PyQt5
-QtCore.qAbs = _QtCore.qAbs
-# QtCore.qAcos = _QtCore.qAcos  # Not in PyQt4
-QtCore.qAddPostRoutine = _QtCore.qAddPostRoutine
-# QtCore.qAsin = _QtCore.qAsin  # Not in PyQt4
-# QtCore.qAtan = _QtCore.qAtan  # Not in PyQt4
-# QtCore.qAtan2 = _QtCore.qAtan2  # Not in PyQt4
-QtCore.qChecksum = _QtCore.qChecksum
-QtCore.qCritical = _QtCore.qCritical
-QtCore.qDebug = _QtCore.qDebug
-# QtCore.qExp = _QtCore.qExp  # Not in PyQt4
-# QtCore.qFabs = _QtCore.qFabs   # Not in PyQt4
-# QtCore.qFastCos = _QtCore.qFastCos  # Not in PyQt4
-# QtCore.qFastSin = _QtCore.qFastSin  # Not in PyQt4
-QtCore.qFatal = _QtCore.qFatal
-QtCore.qFuzzyCompare = _QtCore.qFuzzyCompare
-# QtCore.qFuzzyIsNull = _QtCore.qFuzzyIsNull  # Not in PyQt4
-# QtCore.qInstallMessageHandler = _QtCore.qInstallMessageHandler  # Not in docs?
-QtCore.qIsFinite = _QtCore.qIsFinite
-QtCore.qIsInf = _QtCore.qIsInf
-QtCore.qIsNaN = _QtCore.qIsNaN
-QtCore.qIsNull = _QtCore.qIsNull
-QtCore.qRegisterResourceData = _QtCore.qRegisterResourceData
-# QtCore.qTan = _QtCore.qTan  # Not in PyQt4
-QtCore.qUnregisterResourceData = _QtCore.qUnregisterResourceData
-QtCore.qVersion = _QtCore.qVersion
-QtCore.qWarning = _QtCore.qWarning
-QtCore.qrand = _QtCore.qrand
-QtCore.qsrand = _QtCore.qsrand
-# QtCore.qtTrI = _QtCore.qtTrId  # Not in PyQt4
+# Enable direct import of submodules
+# E.g. import Qt.QtCore
+sys.modules.update({
+    __name__ + ".QtGui": QtGui,
+    __name__ + ".QtCore": QtCore,
+    __name__ + ".QtWidgets": QtWidgets,
+    __name__ + ".QtCompat": QtCompat,
+})
 
 
 """
@@ -885,4 +847,4 @@ del(_QtGui)
 del(_QtWidgets)
 del(_bindings)
 del(_binding)
-del(_found_finding)
+del(_found_binding)

--- a/Qt.py
+++ b/Qt.py
@@ -355,8 +355,16 @@ if not _found_binding:
     raise ImportError("No Qt binding were found.")
 
 
-# Members of Qt.py in Strict Mode.
-# Find or add excluded members in build_membership.py
+"""Members of Qt.py
+
+This is where each member of Qt.py is explicitly defined.
+It is based on a "lowest commond denominator" of all bindings;
+including members found in each of the 4 bindings.
+
+Find or add excluded members in build_membership.py
+
+"""
+
 _strict_members = {
     "QtGui": [
         "QAbstractTextDocumentLayout",
@@ -882,49 +890,32 @@ _strict_members = {
     ]
 }
 
-QtCompat.__version__ = "0.7.0"
+"""Augment QtCompat
+
+QtCompat contains wrappers and added functionality
+to the original bindings, such as the CLI interface
+and otherwise incompatible members between bindings,
+such as `QHeaderView.setSectionResizeMode`.
+
+"""
+
+QtCompat.__version__ = "1.0.0.b1"
 QtCompat._cli = _cli
 QtCompat._convert = _convert
 
-QtCompat.__added__ = list()     # DEPRECATED
-QtCompat.__remapped__ = list()  # DEPRECATED
-QtCompat.__modified__ = list()  # DEPRECATED
-QtCompat.__wrapper_version__ = "0.7.0"  # DEPRECATED
 
+"""Apply strict mode
 
-def _strict():
-    """Apply strict mode
+This make Qt.py into a subset of PySide2 members that exist
+across all other bindings.
 
-    This make Qt.py into a subset of PySide2 members that exist
-    across all other bindings.
+"""
 
-    """
-
-    for module, members in _strict_members.items():
-        for member in members:
-            orig = getattr(sys.modules[__name__], "_%s" % module)
-            repl = getattr(sys.modules[__name__], module)
-            setattr(repl, member, getattr(orig, member))
-
-
-def _loose():
-    """Apply loose mode
-
-    This forwards attribute access to Qt.py submodules
-    onto the original binding.
-
-    """
-
-    self = sys.modules[__name__]
-    self.QtWidgets = self._QtWidgets
-    self.QtGui = self._QtGui
-    self.QtCore = self._QtCore
-    self.QtNetwork = self._QtNetwork
-    self.QtHelp = self._QtHelp
-    self.QtXml = self._QtXml
-
-
-_strict() if QT_STRICT else _loose()
+for module, members in _strict_members.items():
+    for member in members:
+        orig = getattr(sys.modules[__name__], "_%s" % module)
+        repl = getattr(sys.modules[__name__], module)
+        setattr(repl, member, getattr(orig, member))
 
 
 # Enable direct import of submodules

--- a/Qt.py
+++ b/Qt.py
@@ -62,7 +62,15 @@ import sys
 import types
 import shutil
 
-__all__ = ["QtGui", "QtCore", "QtWidgets", "QtCompat"]
+__all__ = [
+    "QtGui",
+    "QtCore",
+    "QtWidgets",
+    "QtNetwork",
+    "QtXml",
+    "QtHelp",
+    "QtCompat"
+]
 
 # Flags from environment variables
 QT_VERBOSE = bool(os.getenv("QT_VERBOSE"))
@@ -73,6 +81,10 @@ QT_STRICT = bool(os.getenv("QT_STRICT"))
 QtGui = types.ModuleType("QtGui")
 QtCore = types.ModuleType("QtCore")
 QtWidgets = types.ModuleType("QtWidgets")
+QtWidgets = types.ModuleType("QtWidgets")
+QtNetwork = types.ModuleType("QtNetwork")
+QtXml = types.ModuleType("QtXml")
+QtHelp = types.ModuleType("QtHelp")
 QtCompat = types.ModuleType("QtCompat")
 
 # To use other modules, such as QtTest and QtScript,
@@ -80,7 +92,16 @@ QtCompat = types.ModuleType("QtCompat")
 
 
 def _pyside2():
-    from PySide2 import QtWidgets, QtGui, QtCore, QtUiTools, __version__
+    from PySide2 import (
+        QtWidgets,
+        QtGui,
+        QtCore,
+        QtNetwork,
+        QtXml,
+        QtHelp,
+        QtUiTools,
+        __version__
+    )
 
     QtCompat.__binding__ = "PySide2"
     QtCompat.__qt_version__ = QtCore.qVersion()
@@ -89,11 +110,19 @@ def _pyside2():
     QtCompat.setSectionResizeMode = QtWidgets.QHeaderView.setSectionResizeMode
     QtCompat.translate = QtCore.QCoreApplication.translate
 
-    return QtCore, QtGui, QtWidgets
+    return QtCore, QtGui, QtWidgets, QtNetwork, QtXml, QtHelp
 
 
 def _pyside():
-    from PySide import QtGui, QtCore, QtUiTools, __version__
+    from PySide import (
+        QtGui,
+        QtCore,
+        QtNetwork,
+        QtXml,
+        QtHelp,
+        QtUiTools,
+        __version__
+    )
 
     QtWidgets = QtGui
 
@@ -109,11 +138,19 @@ def _pyside():
                                           disambiguation,
                                           QtCore.QCoreApplication.CodecForTr,
                                           n))
-    return QtCore, QtGui, QtWidgets
+    return QtCore, QtGui, QtWidgets, QtNetwork, QtXml, QtHelp
 
 
 def _pyqt5():
-    from PyQt5 import QtWidgets, QtGui, QtCore, uic
+    from PyQt5 import (
+        QtWidgets,
+        QtGui,
+        QtCore,
+        QtNetwork,
+        QtXml,
+        QtHelp,
+        uic
+    )
 
     QtCompat.__binding__ = "PyQt5"
     QtCompat.__qt_version__ = QtCore.QT_VERSION_STR
@@ -122,7 +159,7 @@ def _pyqt5():
     QtCompat.translate = QtCore.QCoreApplication.translate
     QtCompat.setSectionResizeMode = QtWidgets.QHeaderView.setSectionResizeMode
 
-    return QtCore, QtGui, QtWidgets
+    return QtCore, QtGui, QtWidgets, QtNetwork, QtXml, QtHelp
 
 
 def _pyqt4():
@@ -142,7 +179,14 @@ def _pyqt4():
         # API version already set to v1
         raise ImportError(str(e))
 
-    from PyQt4 import QtGui, QtCore, uic
+    from PyQt4 import (
+        QtGui,
+        QtCore,
+        QtNetwork,
+        QtXml,
+        QtHelp,
+        uic
+    )
 
     QtWidgets = QtGui
 
@@ -164,7 +208,7 @@ def _pyqt4():
                                           QtCore.QCoreApplication.CodecForTr,
                                           n))
 
-    return QtCore, QtGui, QtWidgets
+    return QtCore, QtGui, QtWidgets, QtNetwork, QtXml, QtHelp
 
 
 def _none():
@@ -178,7 +222,7 @@ def _none():
     QtCompat.load_ui = lambda fname: None
     QtCompat.setSectionResizeMode = lambda *args, **kwargs: None
 
-    return Mock(), Mock(), Mock()
+    return Mock(), Mock(), Mock(), Mock(), Mock(), Mock()
 
 
 def _log(text):
@@ -298,7 +342,7 @@ for _binding in _bindings:
     _log("Trying %s" % _binding.__name__)
 
     try:
-        _QtCore, _QtGui, _QtWidgets = _binding()
+        _QtCore, _QtGui, _QtWidgets, _QtNetwork, _QtXml, _QtHelp = _binding()
         _found_binding = True
         break
 
@@ -761,6 +805,80 @@ _strict_members = {
         "qWarning",
         "qrand",
         "qsrand",
+    ],
+    "QtXml": [
+        "QDomAttr",
+        "QDomCDATASection",
+        "QDomCharacterData",
+        "QDomComment",
+        "QDomDocument",
+        "QDomDocumentFragment",
+        "QDomDocumentType",
+        "QDomElement",
+        "QDomEntity",
+        "QDomEntityReference",
+        "QDomImplementation",
+        "QDomNamedNodeMap",
+        "QDomNode",
+        "QDomNodeList",
+        "QDomNotation",
+        "QDomProcessingInstruction",
+        "QDomText",
+        "QXmlAttributes",
+        "QXmlContentHandler",
+        "QXmlDTDHandler",
+        "QXmlDeclHandler",
+        "QXmlDefaultHandler",
+        "QXmlEntityResolver",
+        "QXmlErrorHandler",
+        "QXmlInputSource",
+        "QXmlLexicalHandler",
+        "QXmlLocator",
+        "QXmlNamespaceSupport",
+        "QXmlParseException",
+        "QXmlReader",
+        "QXmlSimpleReader"
+    ],
+    "QtHelp": [
+        "QHelpContentItem",
+        "QHelpContentModel",
+        "QHelpContentWidget",
+        "QHelpEngine",
+        "QHelpEngineCore",
+        "QHelpIndexModel",
+        "QHelpIndexWidget",
+        "QHelpSearchEngine",
+        "QHelpSearchQuery",
+        "QHelpSearchQueryWidget",
+        "QHelpSearchResultWidget"
+    ],
+    "QtNetwork": [
+        "QAbstractNetworkCache",
+        "QAbstractSocket",
+        "QAuthenticator",
+        "QHostAddress",
+        "QHostInfo",
+        "QLocalServer",
+        "QLocalSocket",
+        "QNetworkAccessManager",
+        "QNetworkAddressEntry",
+        "QNetworkCacheMetaData",
+        "QNetworkConfiguration",
+        "QNetworkConfigurationManager",
+        "QNetworkCookie",
+        "QNetworkCookieJar",
+        "QNetworkDiskCache",
+        "QNetworkInterface",
+        "QNetworkProxy",
+        "QNetworkProxyFactory",
+        "QNetworkProxyQuery",
+        "QNetworkReply",
+        "QNetworkRequest",
+        "QNetworkSession",
+        "QSsl",
+        "QTcpServer",
+        "QTcpSocket",
+        "QUdpSocket"
     ]
 }
 
@@ -801,6 +919,9 @@ def _loose():
     self.QtWidgets = self._QtWidgets
     self.QtGui = self._QtGui
     self.QtCore = self._QtCore
+    self.QtNetwork = self._QtNetwork
+    self.QtHelp = self._QtHelp
+    self.QtXml = self._QtXml
 
 
 _strict() if QT_STRICT else _loose()
@@ -812,6 +933,9 @@ sys.modules.update({
     __name__ + ".QtGui": QtGui,
     __name__ + ".QtCore": QtCore,
     __name__ + ".QtWidgets": QtWidgets,
+    __name__ + ".QtXml": QtXml,
+    __name__ + ".QtNetwork": QtNetwork,
+    __name__ + ".QtHelp": QtHelp,
     __name__ + ".QtCompat": QtCompat,
 })
 

--- a/Qt.py
+++ b/Qt.py
@@ -62,6 +62,8 @@ import sys
 import types
 import shutil
 
+__version__ = "1.0.0.b1"
+
 # Enable support for `from Qt import *`
 __all__ = [
     "QtGui",
@@ -87,6 +89,7 @@ QtNetwork = types.ModuleType("QtNetwork")
 QtXml = types.ModuleType("QtXml")
 QtHelp = types.ModuleType("QtHelp")
 QtCompat = types.ModuleType("QtCompat")
+Qt = sys.modules[__name__]  # Reference to this module
 
 # To use other modules, such as QtTest and QtScript,
 # use conditional branching and import these explicitly.
@@ -104,9 +107,9 @@ def _pyside2():
         __version__
     )
 
-    QtCompat.__binding__ = "PySide2"
-    QtCompat.__qt_version__ = QtCore.qVersion()
-    QtCompat.__binding_version__ = __version__
+    Qt.__binding__ = "PySide2"
+    Qt.__qt_version__ = QtCore.qVersion()
+    Qt.__binding_version__ = __version__
     QtCompat.load_ui = lambda fname: QtUiTools.QUiLoader().load(fname)
     QtCompat.setSectionResizeMode = QtWidgets.QHeaderView.setSectionResizeMode
     QtCompat.translate = QtCore.QCoreApplication.translate
@@ -127,9 +130,9 @@ def _pyside():
 
     QtWidgets = QtGui
 
-    QtCompat.__binding__ = "PySide"
-    QtCompat.__qt_version__ = QtCore.qVersion()
-    QtCompat.__binding_version__ = __version__
+    Qt.__binding__ = "PySide"
+    Qt.__qt_version__ = QtCore.qVersion()
+    Qt.__binding_version__ = __version__
     QtCompat.load_ui = lambda fname: QtUiTools.QUiLoader().load(fname)
     QtCompat.setSectionResizeMode = QtGui.QHeaderView.setResizeMode
     QtCompat.translate = (
@@ -153,9 +156,9 @@ def _pyqt5():
         uic
     )
 
-    QtCompat.__binding__ = "PyQt5"
-    QtCompat.__qt_version__ = QtCore.QT_VERSION_STR
-    QtCompat.__binding_version__ = QtCore.PYQT_VERSION_STR
+    Qt.__binding__ = "PyQt5"
+    Qt.__qt_version__ = QtCore.QT_VERSION_STR
+    Qt.__binding_version__ = QtCore.PYQT_VERSION_STR
     QtCompat.load_ui = lambda fname: uic.loadUi(fname)
     QtCompat.translate = QtCore.QCoreApplication.translate
     QtCompat.setSectionResizeMode = QtWidgets.QHeaderView.setSectionResizeMode
@@ -191,9 +194,9 @@ def _pyqt4():
 
     QtWidgets = QtGui
 
-    QtCompat.__binding__ = "PyQt4"
-    QtCompat.__qt_version__ = QtCore.QT_VERSION_STR
-    QtCompat.__binding_version__ = QtCore.PYQT_VERSION_STR
+    Qt.__binding__ = "PyQt4"
+    Qt.__qt_version__ = QtCore.QT_VERSION_STR
+    Qt.__binding_version__ = QtCore.PYQT_VERSION_STR
     QtCompat.load_ui = lambda fname: uic.loadUi(fname)
     QtCompat.setSectionResizeMode = QtGui.QHeaderView.setResizeMode
 
@@ -215,11 +218,11 @@ def _pyqt4():
 def _none():
     """Internal option (used in installer)"""
 
-    Mock = type("Mock", (), {"__getattr__": lambda self, attr: None})
+    Mock = type("Mock", (), {"__getattr__": lambda Qt, attr: None})
 
-    QtCompat.__binding__ = "None"
-    QtCompat.__qt_version__ = "0.0.0"
-    QtCompat.__binding_version__ = "0.0.0"
+    Qt.__binding__ = "None"
+    Qt.__qt_version__ = "0.0.0"
+    Qt.__binding_version__ = "0.0.0"
     QtCompat.load_ui = lambda fname: None
     QtCompat.setSectionResizeMode = lambda *args, **kwargs: None
 
@@ -900,7 +903,6 @@ such as `QHeaderView.setSectionResizeMode`.
 
 """
 
-QtCompat.__version__ = "1.0.0.b1"
 QtCompat._cli = _cli
 QtCompat._convert = _convert
 
@@ -944,35 +946,35 @@ TODO: This is difficult to read, compared to the above dictionary.
 
 """
 
-if "PySide2" == QtCompat.__binding__:
+if "PySide2" == Qt.__binding__:
     QtCore.QAbstractProxyModel = _QtCore.QAbstractProxyModel
     QtCore.QSortFilterProxyModel = _QtCore.QSortFilterProxyModel
     QtCore.QStringListModel = _QtGui.QStringListModel
     QtCore.QItemSelection = _QtCore.QItemSelection
     QtCore.QItemSelectionModel = _QtCore.QItemSelectionModel
 
-if "PyQt5" == QtCompat.__binding__:
+if "PyQt5" == Qt.__binding__:
     QtCore.QAbstractProxyModel = _QtCore.QAbstractProxyModel
     QtCore.QSortFilterProxyModel = _QtCore.QSortFilterProxyModel
     QtCore.QStringListModel = _QtCore.QStringListModel
     QtCore.QItemSelection = _QtCore.QItemSelection
     QtCore.QItemSelectionModel = _QtCore.QItemSelectionModel
 
-if "PySide" == QtCompat.__binding__:
+if "PySide" == Qt.__binding__:
     QtCore.QAbstractProxyModel = _QtGui.QAbstractProxyModel
     QtCore.QSortFilterProxyModel = _QtGui.QSortFilterProxyModel
     QtCore.QStringListModel = _QtGui.QStringListModel
     QtCore.QItemSelection = _QtGui.QItemSelection
     QtCore.QItemSelectionModel = _QtGui.QItemSelectionModel
 
-if "PyQt4" == QtCompat.__binding__:
+if "PyQt4" == Qt.__binding__:
     QtCore.QAbstractProxyModel = _QtGui.QAbstractProxyModel
     QtCore.QSortFilterProxyModel = _QtGui.QSortFilterProxyModel
     QtCore.QItemSelection = _QtGui.QItemSelection
     QtCore.QStringListModel = _QtGui.QStringListModel
     QtCore.QItemSelectionModel = _QtGui.QItemSelectionModel
 
-if "PyQt" in QtCompat.__binding__:
+if "PyQt" in Qt.__binding__:
     QtCore.Property = _QtCore.pyqtProperty
     QtCore.Signal = _QtCore.pyqtSignal
     QtCore.Slot = _QtCore.pyqtSlot

--- a/Qt.py
+++ b/Qt.py
@@ -874,3 +874,7 @@ del(_QtWidgets)
 del(_bindings)
 del(_binding)
 del(_found_binding)
+
+# Enable command-line interface
+if __name__ == "__main__":
+    _cli(sys.argv[1:])

--- a/Qt.py
+++ b/Qt.py
@@ -312,6 +312,7 @@ if not _found_binding:
 
 
 # Members of Qt.py in Strict Mode.
+# Find or add excluded members in build_membership.py
 _strict_members = {
     "QtGui": [
         "QAbstractTextDocumentLayout",
@@ -490,7 +491,6 @@ _strict_members = {
         "QGraphicsEllipseItem",
         "QGraphicsGridLayout",
         "QGraphicsItem",
-        # "QGraphicsItemAnimation",  # Not in PyQt4
         "QGraphicsItemGroup",
         "QGraphicsLayout",
         "QGraphicsLayoutItem",

--- a/Qt.py
+++ b/Qt.py
@@ -1,6 +1,6 @@
 """The MIT License (MIT)
 
-Copyright (c) 2016 Marcus Ottosson
+Copyright (c) 2016-2017 Marcus Ottosson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -20,40 +20,21 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
----
 
-Map all bindings to PySide2
+Documentation
 
-This module replaces itself with the most desirable binding.
+    All members of PySide2 are mapped from other bindings, should they exist.
+    If no equivalent member exist, it is excluded from Qt.py and inaccessible.
+    The idea is to highlight members that exist across all supported binding,
+    and guarantee that code that runs on one binding runs on all others.
 
-Project goals:
-    Qt.py was born in the film and visual effects industry to address
-    the growing need for the development of software capable of running
-    with more than one flavour of the Qt bindings for Python - PySide,
-    PySide2, PyQt4 and PyQt5.
-
-    1. Build for one, run with all
-    2. Explicit is better than implicit
-    3. Support co-existence
-
-Default resolution order:
-    - PySide2
-    - PyQt5
-    - PySide
-    - PyQt4
-
-Usage:
-    >> import sys
-    >> from Qt import QtWidgets
-    >> app = QtWidgets.QApplication(sys.argv)
-    >> button = QtWidgets.QPushButton("Hello World")
-    >> button.show()
-    >> app.exec_()
+    For more details, visit https://github.com/mottosso/Qt.py
 
 """
 
 import os
 import sys
+import types
 import shutil
 
 # Flags from environment variables
@@ -61,53 +42,21 @@ QT_VERBOSE = bool(os.getenv("QT_VERBOSE"))                # Extra output
 QT_TESTING = bool(os.getenv("QT_TESTING"))                # Extra constraints
 QT_PREFERRED_BINDING = os.getenv("QT_PREFERRED_BINDING")  # Override default
 
-self = sys.modules[__name__]
+# Supported submodules
+Qt = types.ModuleType("Qt")
+QtGui = types.ModuleType("QtGui")
+QtCore = types.ModuleType("QtCore")
+QtWidgets = types.ModuleType("QtWidgets")
+QtCompat = types.ModuleType("QtCompat")
 
-# Internal members, may be used externally for debugging
-self.__added__ = list()     # All members added to QtCompat
-self.__remapped__ = list()  # Members copied from elsewhere
-self.__modified__ = list()  # Existing members modified in some way
-
-# Below members are set dynamically on import relative the original binding.
-self.__version__ = "0.6.9"
-self.__qt_version__ = "0.0.0"
-self.__binding__ = "None"
-self.__binding_version__ = "0.0.0"
-
-self.load_ui = lambda fname: None
-self.translate = lambda context, sourceText, disambiguation, n: None
-self.setSectionResizeMode = lambda logicalIndex, hide: None
-
-# All members of this module is directly accessible via QtCompat
-# Take care not to access any "private" members; i.e. those with
-# a leading underscore.
-QtCompat = self
-
-
-def convert(lines):
-    """Convert compiled .ui file from PySide2 to Qt.py
-
-    Arguments:
-        lines (list): Each line of of .ui file
-
-    Usage:
-        >> with open("myui.py") as f:
-        ..   lines = convert(f.readlines())
-
-    """
-
-    def parse(line):
-        line = line.replace("from PySide2 import", "from Qt import")
-        line = line.replace("QtWidgets.QApplication.translate",
-                            "Qt.QtCompat.translate")
-        return line
-
-    parsed = list()
-    for line in lines:
-        line = parse(line)
-        parsed.append(line)
-
-    return parsed
+# Enable direct import of submodules
+# E.g. import Qt.QtCore
+sys.modules.update({
+    __name__ + ".QtGui": QtGui,
+    __name__ + ".QtCore": QtCore,
+    __name__ + ".QtWidgets": QtWidgets,
+    __name__ + ".QtCompat": QtCompat,
+})
 
 
 def _remap(object, name, value, safe=True):
@@ -137,42 +86,66 @@ def _remap(object, name, value, safe=True):
 
     elif hasattr(object, name):
         # Keep track of modifications
-        self.__modified__.append(name)
+        QtCompat.__modified__.append(name)
 
-    self.__remapped__.append(name)
+    QtCompat.__remapped__.append(name)
 
     setattr(object, name, value)
 
 
 def _add(object, name, value):
     """Append to self, accessible via Qt.QtCompat"""
-    self.__added__.append(name)
+    QtCompat.__added__.append(name)
     setattr(object, name, value)
 
 
+def _pyside2():
+    from PySide2 import QtWidgets, QtGui, QtCore, QtUiTools, __version__
+
+    QtCompat.__binding__ = "PySide2"
+    QtCompat.__qt_version__ = QtCore.qVersion()
+    QtCompat.__binding_version__ = __version__
+    QtCompat.load_ui = lambda fname: QtUiTools.QUiLoader().load(fname)
+    QtCompat.setSectionResizeMode = QtWidgets.QHeaderView.setSectionResizeMode
+    QtCompat.translate = QtCore.QCoreApplication.translate
+
+    return QtCore, QtGui, QtWidgets
+
+
+def _pyside():
+    from PySide import QtGui, QtCore, QtUiTools, __version__
+
+    QtWidgets = QtGui
+
+    QtCompat.__binding__ = "PySide"
+    QtCompat.__qt_version__ = QtCore.qVersion()
+    QtCompat.__binding_version__ = __version__
+    QtCompat.load_ui = lambda fname: QtUiTools.QUiLoader().load(fname)
+    QtCompat.setSectionResizeMode = QtGui.QHeaderView.setResizeMode
+    QtCompat.translate = (
+        lambda context, sourceText, disambiguation, n:
+        QtCore.QCoreApplication.translate(context,
+                                          sourceText,
+                                          disambiguation,
+                                          QtCore.QCoreApplication.CodecForTr,
+                                          n))
+    return QtCore, QtGui, QtWidgets
+
+
 def _pyqt5():
-    import PyQt5.Qt
-    from PyQt5 import QtCore, QtWidgets, uic
+    from PyQt5 import QtWidgets, QtGui, QtCore, uic
 
-    _remap(QtCore, "Signal", QtCore.pyqtSignal)
-    _remap(QtCore, "Slot", QtCore.pyqtSlot)
-    _remap(QtCore, "Property", QtCore.pyqtProperty)
+    QtCompat.__binding__ = "PyQt5"
+    QtCompat.__qt_version__ = QtCore.QT_VERSION_STR
+    QtCompat.__binding_version__ = QtCore.PYQT_VERSION_STR
+    QtCompat.load_ui = lambda fname: uic.loadUi(fname)
+    QtCompat.translate = QtCore.QCoreApplication.translate
+    QtCompat.setSectionResizeMode = QtWidgets.QHeaderView.setSectionResizeMode
 
-    _add(QtCompat, "__binding__", PyQt5.__name__)
-    _add(QtCompat, "__binding_version__", PyQt5.QtCore.PYQT_VERSION_STR)
-    _add(QtCompat, "__qt_version__", PyQt5.QtCore.QT_VERSION_STR)
-    _add(QtCompat, "load_ui", lambda fname: uic.loadUi(fname))
-    _add(QtCompat, "translate", QtCore.QCoreApplication.translate)
-    _add(QtCompat, "setSectionResizeMode",
-         QtWidgets.QHeaderView.setSectionResizeMode)
-
-    _maintain_backwards_compatibility(PyQt5)
-
-    return PyQt5
+    return QtCore, QtGui, QtWidgets
 
 
 def _pyqt4():
-    # Attempt to set sip API v2 (must be done prior to importing PyQt4)
     import sip
     try:
         sip.setapi("QString", 2)
@@ -189,112 +162,122 @@ def _pyqt4():
         # API version already set to v1
         raise ImportError
 
-    import PyQt4.Qt
-    from PyQt4 import QtCore, QtGui, uic
+    from PyQt4 import QtGui, QtCore, uic
 
+    QtWidgets = QtGui
 
-    _remap(PyQt4, "QtWidgets", QtGui)
-    _remap(QtCore, "Signal", QtCore.pyqtSignal)
-    _remap(QtCore, "Slot", QtCore.pyqtSlot)
-    _remap(QtCore, "Property", QtCore.pyqtProperty)
-    _remap(QtCore, "QItemSelection", QtGui.QItemSelection)
-    _remap(QtCore, "QStringListModel", QtGui.QStringListModel)
-    _remap(QtCore, "QItemSelectionModel", QtGui.QItemSelectionModel)
-    _remap(QtCore, "QSortFilterProxyModel", QtGui.QSortFilterProxyModel)
-    _remap(QtCore, "QAbstractProxyModel", QtGui.QAbstractProxyModel)
-
-    try:
-        from PyQt4 import QtWebKit
-        _remap(PyQt4, "QtWebKitWidgets", QtWebKit)
-    except ImportError:
-        "QtWebkit is optional in Qt , therefore might not be available"
-
-    _add(QtCompat, "__binding__", PyQt4.__name__)
-    _add(QtCompat, "__binding_version__", PyQt4.QtCore.PYQT_VERSION_STR)
-    _add(QtCompat, "__qt_version__", PyQt4.QtCore.QT_VERSION_STR)
-    _add(QtCompat, "load_ui", lambda fname: uic.loadUi(fname))
-    _add(QtCompat, "setSectionResizeMode", QtGui.QHeaderView.setResizeMode)
+    QtCompat.__binding__ = "PyQt4"
+    QtCompat.__qt_version__ = QtCore.QT_VERSION_STR
+    QtCompat.__binding_version__ = QtCore.PYQT_VERSION_STR
+    QtCompat.load_ui = lambda fname: uic.loadUi(fname)
+    QtCompat.setSectionResizeMode = QtGui.QHeaderView.setResizeMode
 
     # PySide2 differs from Qt4 in that Qt4 has one extra argument
     # which is always `None`. The lambda arguments represents the PySide2
     # interface, whereas the arguments passed to `.translate` represent
     # those expected of a Qt4 binding.
-    _add(QtCompat, "translate",
-         lambda context, sourceText, disambiguation, n:
-         QtCore.QCoreApplication.translate(context,
-                                           sourceText,
-                                           disambiguation,
-                                           QtCore.QCoreApplication.CodecForTr,
-                                           n))
+    QtCompat.translate = (
+        lambda context, sourceText, disambiguation, n:
+        QtCore.QCoreApplication.translate(context,
+                                          sourceText,
+                                          disambiguation,
+                                          QtCore.QCoreApplication.CodecForTr,
+                                          n))
 
-    _maintain_backwards_compatibility(PyQt4)
-
-    return PyQt4
+    return QtCore, QtGui, QtWidgets
 
 
-def _pyside2():
-    import PySide2
-    from PySide2 import QtGui, QtWidgets, QtCore, QtUiTools
+def _none():
+    """Internal option (used in installer)"""
 
-    _remap(QtCore, "QStringListModel", QtGui.QStringListModel)
+    Mock = type("Mock", (), {"__getattr__": lambda self, attr: None})
 
-    _add(QtCompat, "__binding__", PySide2.__name__)
-    _add(QtCompat, "__binding_version__", PySide2.__version__)
-    _add(QtCompat, "__qt_version__", PySide2.QtCore.qVersion())
-    _add(QtCompat, "load_ui", lambda fname: QtUiTools.QUiLoader().load(fname))
+    QtCompat.__binding__ = "None"
+    QtCompat.__qt_version__ = "0.0.0"
+    QtCompat.__binding_version__ = "0.0.0"
+    QtCompat.load_ui = lambda fname: None
+    QtCompat.setSectionResizeMode = lambda *args, **kwargs: None
 
-    _add(QtCompat, "setSectionResizeMode",
-         QtWidgets.QHeaderView.setSectionResizeMode)
-
-    _add(QtCompat, "translate", QtCore.QCoreApplication.translate)
-
-    _maintain_backwards_compatibility(PySide2)
-
-    return PySide2
+    return Mock(), Mock(), Mock()
 
 
-def _pyside():
-    import PySide
-    from PySide import QtGui, QtCore, QtUiTools
-
-    _remap(PySide, "QtWidgets", QtGui)
-    _remap(QtCore, "QSortFilterProxyModel", QtGui.QSortFilterProxyModel)
-    _remap(QtCore, "QStringListModel", QtGui.QStringListModel)
-    _remap(QtCore, "QItemSelection", QtGui.QItemSelection)
-    _remap(QtCore, "QItemSelectionModel", QtGui.QItemSelectionModel)
-    _remap(QtCore, "QAbstractProxyModel", QtGui.QAbstractProxyModel)
-
-    try:
-        from PySide import QtWebKit
-        _remap(PySide, "QtWebKitWidgets", QtWebKit)
-    except ImportError:
-        "QtWebkit is optional in Qt, therefore might not be available"
-
-    _add(QtCompat, "__binding__", PySide.__name__)
-    _add(QtCompat, "__binding_version__", PySide.__version__)
-    _add(QtCompat, "__qt_version__", PySide.QtCore.qVersion())
-    _add(QtCompat, "load_ui", lambda fname: QtUiTools.QUiLoader().load(fname))
-    _add(QtCompat, "setSectionResizeMode", QtGui.QHeaderView.setResizeMode)
-
-    _add(QtCompat, "translate",
-         lambda context, sourceText, disambiguation, n:
-         QtCore.QCoreApplication.translate(context,
-                                           sourceText,
-                                           disambiguation,
-                                           QtCore.QCoreApplication.CodecForTr,
-                                           n))
-
-    _maintain_backwards_compatibility(PySide)
-
-    return PySide
-
-
-def _log(text, verbose):
-    if verbose:
+def _log(text):
+    if QT_VERBOSE:
         sys.stdout.write(text + "\n")
 
 
-def cli(args):
+# Default order (customise order and content via QT_PREFERRED_BINDING)
+_bindings = (_pyside2, _pyqt5, _pyside, _pyqt4)
+
+if QT_PREFERRED_BINDING:
+    _preferred = QT_PREFERRED_BINDING.split(os.pathsep)
+    _available = {
+        "PySide2": _pyside2,
+        "PyQt5": _pyqt5,
+        "PySide": _pyside,
+        "PyQt4": _pyqt4,
+        "None": _none
+    }
+
+    try:
+        _bindings = [_available[binding] for binding in _preferred]
+    except KeyError:
+        raise ImportError(
+            ("Requested %s, available: " % _preferred) +
+            "\n".join(_available.keys())
+        )
+
+    del(_preferred)
+    del(_available)
+
+_log("Preferred binding: %s" % list(_b.__name__ for _b in _bindings))
+
+
+_found_finding = False
+for _binding in _bindings:
+    _log("Trying %s" % _binding.__name__)
+
+    try:
+        _QtCore, _QtGui, _QtWidgets = _binding()
+        _found_finding = True
+        break
+
+    except ImportError as e:
+        _log("ImportError(\"%s\")" % e)
+        continue
+
+if not _found_finding:
+    # If not binding were found, throw this error
+    raise ImportError("No Qt binding were found.")
+
+
+def convert(lines):
+    """Convert compiled .ui file from PySide2 to Qt.py
+
+    Arguments:
+        lines (list): Each line of of .ui file
+
+    Usage:
+        >> with open("myui.py") as f:
+        ..   lines = convert(f.readlines())
+
+    """
+
+    def parse(line):
+        line = line.replace("from PySide2 import", "from Qt import")
+        line = line.replace("QtWidgets.QApplication.translate",
+                            "Qt.QtCompat.translate")
+        return line
+
+    parsed = list()
+    for line in lines:
+        line = parse(line)
+        parsed.append(line)
+
+    return parsed
+
+
+def _cli(args):
     """Qt.py command-line interface"""
     import argparse
 
@@ -348,99 +331,558 @@ def cli(args):
         sys.stdout.write("Successfully converted \"%s\"\n" % args.convert)
 
 
-def init():
-    """Try loading each binding in turn
+QtCompat.__added__ = list()     # All members added to QtCompat
+QtCompat.__remapped__ = list()  # Members copied from elsewhere
+QtCompat.__modified__ = list()  # Existing members modified in some way
+QtCompat.__version__ = "0.7.0"
+QtCompat._remap = _remap
+QtCompat._add = _add
+QtCompat.cli = _cli
 
-    Please note: the entire Qt module is replaced with this code:
-        sys.modules["Qt"] = binding()
+QtGui.QAbstractTextDocumentLayout = _QtGui.QAbstractTextDocumentLayout
+# QtGui.QAccessibleEvent = _QtGui.QAccessibleEvent  # Not in PyQt4
+QtGui.QActionEvent = _QtGui.QActionEvent
+QtGui.QBitmap = _QtGui.QBitmap
+QtGui.QBrush = _QtGui.QBrush
+QtGui.QClipboard = _QtGui.QClipboard
+QtGui.QCloseEvent = _QtGui.QCloseEvent
+QtGui.QColor = _QtGui.QColor
+QtGui.QConicalGradient = _QtGui.QConicalGradient
+QtGui.QContextMenuEvent = _QtGui.QContextMenuEvent
+QtGui.QCursor = _QtGui.QCursor
+QtGui.QDoubleValidator = _QtGui.QDoubleValidator
+QtGui.QDrag = _QtGui.QDrag
+QtGui.QDragEnterEvent = _QtGui.QDragEnterEvent
+QtGui.QDragLeaveEvent = _QtGui.QDragLeaveEvent
+QtGui.QDragMoveEvent = _QtGui.QDragMoveEvent
+QtGui.QDropEvent = _QtGui.QDropEvent
+QtGui.QFileOpenEvent = _QtGui.QFileOpenEvent
+QtGui.QFocusEvent = _QtGui.QFocusEvent
+QtGui.QFont = _QtGui.QFont
+QtGui.QFontDatabase = _QtGui.QFontDatabase
+QtGui.QFontInfo = _QtGui.QFontInfo
+QtGui.QFontMetrics = _QtGui.QFontMetrics
+QtGui.QFontMetricsF = _QtGui.QFontMetricsF
+QtGui.QGradient = _QtGui.QGradient
+# QtGui.QGuiApplication = _QtGui.QGuiApplication
+QtGui.QHelpEvent = _QtGui.QHelpEvent
+QtGui.QHideEvent = _QtGui.QHideEvent
+QtGui.QHoverEvent = _QtGui.QHoverEvent
+QtGui.QIcon = _QtGui.QIcon
+QtGui.QIconDragEvent = _QtGui.QIconDragEvent
+QtGui.QIconEngine = _QtGui.QIconEngine
+QtGui.QImage = _QtGui.QImage
+QtGui.QImageIOHandler = _QtGui.QImageIOHandler
+QtGui.QImageReader = _QtGui.QImageReader
+QtGui.QImageWriter = _QtGui.QImageWriter
+QtGui.QInputEvent = _QtGui.QInputEvent
+QtGui.QInputMethodEvent = _QtGui.QInputMethodEvent
+QtGui.QIntValidator = _QtGui.QIntValidator
+QtGui.QKeyEvent = _QtGui.QKeyEvent
+QtGui.QKeySequence = _QtGui.QKeySequence
+QtGui.QLinearGradient = _QtGui.QLinearGradient
+# QtGui.QMatrix = _QtGui.QMatrix  # Not in PyQt5
+QtGui.QMatrix2x2 = _QtGui.QMatrix2x2
+QtGui.QMatrix2x3 = _QtGui.QMatrix2x3
+QtGui.QMatrix2x4 = _QtGui.QMatrix2x4
+QtGui.QMatrix3x2 = _QtGui.QMatrix3x2
+QtGui.QMatrix3x3 = _QtGui.QMatrix3x3
+QtGui.QMatrix3x4 = _QtGui.QMatrix3x4
+QtGui.QMatrix4x2 = _QtGui.QMatrix4x2
+QtGui.QMatrix4x3 = _QtGui.QMatrix4x3
+QtGui.QMatrix4x4 = _QtGui.QMatrix4x4
+QtGui.QMouseEvent = _QtGui.QMouseEvent
+QtGui.QMoveEvent = _QtGui.QMoveEvent
+QtGui.QMovie = _QtGui.QMovie
+# QtGui.QPagedPaintDevice = _QtGui.QPagedPaintDevice
+QtGui.QPaintDevice = _QtGui.QPaintDevice
+QtGui.QPaintEngine = _QtGui.QPaintEngine
+QtGui.QPaintEngineState = _QtGui.QPaintEngineState
+QtGui.QPaintEvent = _QtGui.QPaintEvent
+QtGui.QPainter = _QtGui.QPainter
+QtGui.QPainterPath = _QtGui.QPainterPath
+QtGui.QPainterPathStroker = _QtGui.QPainterPathStroker
+QtGui.QPalette = _QtGui.QPalette
+QtGui.QPen = _QtGui.QPen
+QtGui.QPicture = _QtGui.QPicture
+QtGui.QPictureIO = _QtGui.QPictureIO
+QtGui.QPixmap = _QtGui.QPixmap
+QtGui.QPixmapCache = _QtGui.QPixmapCache
+QtGui.QPolygon = _QtGui.QPolygon
+QtGui.QPolygonF = _QtGui.QPolygonF
+# QtGui.QPyTextObject = _QtGui.QPyTextObject  # Not in PyQt5
+QtGui.QQuaternion = _QtGui.QQuaternion
+QtGui.QRadialGradient = _QtGui.QRadialGradient
+QtGui.QRegExpValidator = _QtGui.QRegExpValidator
+QtGui.QRegion = _QtGui.QRegion
+QtGui.QResizeEvent = _QtGui.QResizeEvent
+QtGui.QSessionManager = _QtGui.QSessionManager
+QtGui.QShortcutEvent = _QtGui.QShortcutEvent
+QtGui.QShowEvent = _QtGui.QShowEvent
+QtGui.QStandardItem = _QtGui.QStandardItem
+QtGui.QStandardItemModel = _QtGui.QStandardItemModel
+QtGui.QStatusTipEvent = _QtGui.QStatusTipEvent
+# QtGui.QSurface = _QtGui.QSurface
+# QtGui.QSurfaceFormat = _QtGui.QSurfaceFormat
+QtGui.QSyntaxHighlighter = _QtGui.QSyntaxHighlighter
+QtGui.QTabletEvent = _QtGui.QTabletEvent
+QtGui.QTextBlock = _QtGui.QTextBlock
+QtGui.QTextBlockFormat = _QtGui.QTextBlockFormat
+QtGui.QTextBlockGroup = _QtGui.QTextBlockGroup
+QtGui.QTextBlockUserData = _QtGui.QTextBlockUserData
+QtGui.QTextCharFormat = _QtGui.QTextCharFormat
+QtGui.QTextCursor = _QtGui.QTextCursor
+QtGui.QTextDocument = _QtGui.QTextDocument
+QtGui.QTextDocumentFragment = _QtGui.QTextDocumentFragment
+QtGui.QTextFormat = _QtGui.QTextFormat
+QtGui.QTextFragment = _QtGui.QTextFragment
+QtGui.QTextFrame = _QtGui.QTextFrame
+QtGui.QTextFrameFormat = _QtGui.QTextFrameFormat
+QtGui.QTextImageFormat = _QtGui.QTextImageFormat
+QtGui.QTextInlineObject = _QtGui.QTextInlineObject
+QtGui.QTextItem = _QtGui.QTextItem
+QtGui.QTextLayout = _QtGui.QTextLayout
+QtGui.QTextLength = _QtGui.QTextLength
+QtGui.QTextLine = _QtGui.QTextLine
+QtGui.QTextList = _QtGui.QTextList
+QtGui.QTextListFormat = _QtGui.QTextListFormat
+QtGui.QTextObject = _QtGui.QTextObject
+QtGui.QTextObjectInterface = _QtGui.QTextObjectInterface
+QtGui.QTextOption = _QtGui.QTextOption
+QtGui.QTextTable = _QtGui.QTextTable
+QtGui.QTextTableCell = _QtGui.QTextTableCell
+QtGui.QTextTableCellFormat = _QtGui.QTextTableCellFormat
+QtGui.QTextTableFormat = _QtGui.QTextTableFormat
+# QtGui.QToolBarChangeEvent = _QtGui.QToolBarChangeEvent  # Not in PyQt4
+# QtGui.QTouchDevice = _QtGui.QTouchDevice
+# QtGui.QTouchEvent = _QtGui.QTouchEvent
+QtGui.QTransform = _QtGui.QTransform
+QtGui.QValidator = _QtGui.QValidator
+QtGui.QVector2D = _QtGui.QVector2D
+QtGui.QVector3D = _QtGui.QVector3D
+QtGui.QVector4D = _QtGui.QVector4D
+QtGui.QWhatsThisClickedEvent = _QtGui.QWhatsThisClickedEvent
+QtGui.QWheelEvent = _QtGui.QWheelEvent
+# QtGui.QWindow = _QtGui.QWindow
+QtGui.QWindowStateChangeEvent = _QtGui.QWindowStateChangeEvent
+QtGui.qAlpha = _QtGui.qAlpha
+QtGui.qBlue = _QtGui.qBlue
+QtGui.qGray = _QtGui.qGray
+QtGui.qGreen = _QtGui.qGreen
+QtGui.qIsGray = _QtGui.qIsGray
+QtGui.qRed = _QtGui.qRed
+QtGui.qRgb = _QtGui.qRgb
+QtGui.qRgb = _QtGui.qRgb
 
-    This means no functions or variables can be called after
-    this has executed.
 
-    For debugging and testing, this module may be accessed
-    through `Qt.__shim__`.
+QtWidgets.QAbstractButton = _QtWidgets.QAbstractButton
+QtWidgets.QAbstractGraphicsShapeItem = _QtWidgets.QAbstractGraphicsShapeItem
+QtWidgets.QAbstractItemDelegate = _QtWidgets.QAbstractItemDelegate
+QtWidgets.QAbstractItemView = _QtWidgets.QAbstractItemView
+QtWidgets.QAbstractScrollArea = _QtWidgets.QAbstractScrollArea
+QtWidgets.QAbstractSlider = _QtWidgets.QAbstractSlider
+QtWidgets.QAbstractSpinBox = _QtWidgets.QAbstractSpinBox
+QtWidgets.QAction = _QtWidgets.QAction
+QtWidgets.QActionGroup = _QtWidgets.QActionGroup
+QtWidgets.QApplication = _QtWidgets.QApplication
+QtWidgets.QBoxLayout = _QtWidgets.QBoxLayout
+QtWidgets.QButtonGroup = _QtWidgets.QButtonGroup
+QtWidgets.QCalendarWidget = _QtWidgets.QCalendarWidget
+QtWidgets.QCheckBox = _QtWidgets.QCheckBox
+QtWidgets.QColorDialog = _QtWidgets.QColorDialog
+QtWidgets.QColumnView = _QtWidgets.QColumnView
+QtWidgets.QComboBox = _QtWidgets.QComboBox
+QtWidgets.QCommandLinkButton = _QtWidgets.QCommandLinkButton
+QtWidgets.QCommonStyle = _QtWidgets.QCommonStyle
+QtWidgets.QCompleter = _QtWidgets.QCompleter
+QtWidgets.QDataWidgetMapper = _QtWidgets.QDataWidgetMapper
+QtWidgets.QDateEdit = _QtWidgets.QDateEdit
+QtWidgets.QDateTimeEdit = _QtWidgets.QDateTimeEdit
+QtWidgets.QDesktopWidget = _QtWidgets.QDesktopWidget
+QtWidgets.QDial = _QtWidgets.QDial
+QtWidgets.QDialog = _QtWidgets.QDialog
+QtWidgets.QDialogButtonBox = _QtWidgets.QDialogButtonBox
+QtWidgets.QDirModel = _QtWidgets.QDirModel
+QtWidgets.QDockWidget = _QtWidgets.QDockWidget
+QtWidgets.QDoubleSpinBox = _QtWidgets.QDoubleSpinBox
+QtWidgets.QErrorMessage = _QtWidgets.QErrorMessage
+QtWidgets.QFileDialog = _QtWidgets.QFileDialog
+QtWidgets.QFileIconProvider = _QtWidgets.QFileIconProvider
+QtWidgets.QFileSystemModel = _QtWidgets.QFileSystemModel
+QtWidgets.QFocusFrame = _QtWidgets.QFocusFrame
+QtWidgets.QFontComboBox = _QtWidgets.QFontComboBox
+QtWidgets.QFontDialog = _QtWidgets.QFontDialog
+QtWidgets.QFormLayout = _QtWidgets.QFormLayout
+QtWidgets.QFrame = _QtWidgets.QFrame
+QtWidgets.QGesture = _QtWidgets.QGesture
+QtWidgets.QGestureEvent = _QtWidgets.QGestureEvent
+QtWidgets.QGestureRecognizer = _QtWidgets.QGestureRecognizer
+QtWidgets.QGraphicsAnchor = _QtWidgets.QGraphicsAnchor
+QtWidgets.QGraphicsAnchorLayout = _QtWidgets.QGraphicsAnchorLayout
+QtWidgets.QGraphicsBlurEffect = _QtWidgets.QGraphicsBlurEffect
+QtWidgets.QGraphicsColorizeEffect = _QtWidgets.QGraphicsColorizeEffect
+QtWidgets.QGraphicsDropShadowEffect = _QtWidgets.QGraphicsDropShadowEffect
+QtWidgets.QGraphicsEffect = _QtWidgets.QGraphicsEffect
+QtWidgets.QGraphicsEllipseItem = _QtWidgets.QGraphicsEllipseItem
+QtWidgets.QGraphicsGridLayout = _QtWidgets.QGraphicsGridLayout
+QtWidgets.QGraphicsItem = _QtWidgets.QGraphicsItem
+# QtWidgets.QGraphicsItemAnimation = _QtWidgets.QGraphicsItemAnimation  # Not in PyQt4
+QtWidgets.QGraphicsItemGroup = _QtWidgets.QGraphicsItemGroup
+QtWidgets.QGraphicsLayout = _QtWidgets.QGraphicsLayout
+QtWidgets.QGraphicsLayoutItem = _QtWidgets.QGraphicsLayoutItem
+QtWidgets.QGraphicsLineItem = _QtWidgets.QGraphicsLineItem
+QtWidgets.QGraphicsLinearLayout = _QtWidgets.QGraphicsLinearLayout
+QtWidgets.QGraphicsObject = _QtWidgets.QGraphicsObject
+QtWidgets.QGraphicsOpacityEffect = _QtWidgets.QGraphicsOpacityEffect
+QtWidgets.QGraphicsPathItem = _QtWidgets.QGraphicsPathItem
+QtWidgets.QGraphicsPixmapItem = _QtWidgets.QGraphicsPixmapItem
+QtWidgets.QGraphicsPolygonItem = _QtWidgets.QGraphicsPolygonItem
+QtWidgets.QGraphicsProxyWidget = _QtWidgets.QGraphicsProxyWidget
+QtWidgets.QGraphicsRectItem = _QtWidgets.QGraphicsRectItem
+QtWidgets.QGraphicsRotation = _QtWidgets.QGraphicsRotation
+QtWidgets.QGraphicsScale = _QtWidgets.QGraphicsScale
+QtWidgets.QGraphicsScene = _QtWidgets.QGraphicsScene
+QtWidgets.QGraphicsSceneContextMenuEvent = _QtWidgets.QGraphicsSceneContextMenuEvent
+QtWidgets.QGraphicsSceneDragDropEvent = _QtWidgets.QGraphicsSceneDragDropEvent
+QtWidgets.QGraphicsSceneEvent = _QtWidgets.QGraphicsSceneEvent
+QtWidgets.QGraphicsSceneHelpEvent = _QtWidgets.QGraphicsSceneHelpEvent
+QtWidgets.QGraphicsSceneHoverEvent = _QtWidgets.QGraphicsSceneHoverEvent
+QtWidgets.QGraphicsSceneMouseEvent = _QtWidgets.QGraphicsSceneMouseEvent
+QtWidgets.QGraphicsSceneMoveEvent = _QtWidgets.QGraphicsSceneMoveEvent
+QtWidgets.QGraphicsSceneResizeEvent = _QtWidgets.QGraphicsSceneResizeEvent
+QtWidgets.QGraphicsSceneWheelEvent = _QtWidgets.QGraphicsSceneWheelEvent
+QtWidgets.QGraphicsSimpleTextItem = _QtWidgets.QGraphicsSimpleTextItem
+QtWidgets.QGraphicsTextItem = _QtWidgets.QGraphicsTextItem
+QtWidgets.QGraphicsTransform = _QtWidgets.QGraphicsTransform
+QtWidgets.QGraphicsView = _QtWidgets.QGraphicsView
+QtWidgets.QGraphicsWidget = _QtWidgets.QGraphicsWidget
+QtWidgets.QGridLayout = _QtWidgets.QGridLayout
+QtWidgets.QGroupBox = _QtWidgets.QGroupBox
+QtWidgets.QHBoxLayout = _QtWidgets.QHBoxLayout
+QtWidgets.QHeaderView = _QtWidgets.QHeaderView
+QtWidgets.QInputDialog = _QtWidgets.QInputDialog
+QtWidgets.QItemDelegate = _QtWidgets.QItemDelegate
+QtWidgets.QItemEditorCreatorBase = _QtWidgets.QItemEditorCreatorBase
+QtWidgets.QItemEditorFactory = _QtWidgets.QItemEditorFactory
+QtWidgets.QKeyEventTransition = _QtWidgets.QKeyEventTransition
+QtWidgets.QLCDNumber = _QtWidgets.QLCDNumber
+QtWidgets.QLabel = _QtWidgets.QLabel
+QtWidgets.QLayout = _QtWidgets.QLayout
+QtWidgets.QLayoutItem = _QtWidgets.QLayoutItem
+QtWidgets.QLineEdit = _QtWidgets.QLineEdit
+QtWidgets.QListView = _QtWidgets.QListView
+QtWidgets.QListWidget = _QtWidgets.QListWidget
+QtWidgets.QListWidgetItem = _QtWidgets.QListWidgetItem
+QtWidgets.QMainWindow = _QtWidgets.QMainWindow
+QtWidgets.QMdiArea = _QtWidgets.QMdiArea
+QtWidgets.QMdiSubWindow = _QtWidgets.QMdiSubWindow
+QtWidgets.QMenu = _QtWidgets.QMenu
+QtWidgets.QMenuBar = _QtWidgets.QMenuBar
+QtWidgets.QMessageBox = _QtWidgets.QMessageBox
+QtWidgets.QMouseEventTransition = _QtWidgets.QMouseEventTransition
+QtWidgets.QPanGesture = _QtWidgets.QPanGesture
+QtWidgets.QPinchGesture = _QtWidgets.QPinchGesture
+QtWidgets.QPlainTextDocumentLayout = _QtWidgets.QPlainTextDocumentLayout
+QtWidgets.QPlainTextEdit = _QtWidgets.QPlainTextEdit
+QtWidgets.QProgressBar = _QtWidgets.QProgressBar
+QtWidgets.QProgressDialog = _QtWidgets.QProgressDialog
+QtWidgets.QPushButton = _QtWidgets.QPushButton
+QtWidgets.QRadioButton = _QtWidgets.QRadioButton
+QtWidgets.QRubberBand = _QtWidgets.QRubberBand
+QtWidgets.QScrollArea = _QtWidgets.QScrollArea
+QtWidgets.QScrollBar = _QtWidgets.QScrollBar
+QtWidgets.QShortcut = _QtWidgets.QShortcut
+QtWidgets.QSizeGrip = _QtWidgets.QSizeGrip
+QtWidgets.QSizePolicy = _QtWidgets.QSizePolicy
+QtWidgets.QSlider = _QtWidgets.QSlider
+QtWidgets.QSpacerItem = _QtWidgets.QSpacerItem
+QtWidgets.QSpinBox = _QtWidgets.QSpinBox
+QtWidgets.QSplashScreen = _QtWidgets.QSplashScreen
+QtWidgets.QSplitter = _QtWidgets.QSplitter
+QtWidgets.QSplitterHandle = _QtWidgets.QSplitterHandle
+QtWidgets.QStackedLayout = _QtWidgets.QStackedLayout
+QtWidgets.QStackedWidget = _QtWidgets.QStackedWidget
+QtWidgets.QStatusBar = _QtWidgets.QStatusBar
+QtWidgets.QStyle = _QtWidgets.QStyle
+QtWidgets.QStyleFactory = _QtWidgets.QStyleFactory
+QtWidgets.QStyleHintReturn = _QtWidgets.QStyleHintReturn
+QtWidgets.QStyleHintReturnMask = _QtWidgets.QStyleHintReturnMask
+QtWidgets.QStyleHintReturnVariant = _QtWidgets.QStyleHintReturnVariant
+QtWidgets.QStyleOption = _QtWidgets.QStyleOption
+QtWidgets.QStyleOptionButton = _QtWidgets.QStyleOptionButton
+QtWidgets.QStyleOptionComboBox = _QtWidgets.QStyleOptionComboBox
+QtWidgets.QStyleOptionComplex = _QtWidgets.QStyleOptionComplex
+QtWidgets.QStyleOptionDockWidget = _QtWidgets.QStyleOptionDockWidget
+QtWidgets.QStyleOptionFocusRect = _QtWidgets.QStyleOptionFocusRect
+QtWidgets.QStyleOptionFrame = _QtWidgets.QStyleOptionFrame
+QtWidgets.QStyleOptionGraphicsItem = _QtWidgets.QStyleOptionGraphicsItem
+QtWidgets.QStyleOptionGroupBox = _QtWidgets.QStyleOptionGroupBox
+QtWidgets.QStyleOptionHeader = _QtWidgets.QStyleOptionHeader
+QtWidgets.QStyleOptionMenuItem = _QtWidgets.QStyleOptionMenuItem
+QtWidgets.QStyleOptionProgressBar = _QtWidgets.QStyleOptionProgressBar
+QtWidgets.QStyleOptionRubberBand = _QtWidgets.QStyleOptionRubberBand
+QtWidgets.QStyleOptionSizeGrip = _QtWidgets.QStyleOptionSizeGrip
+QtWidgets.QStyleOptionSlider = _QtWidgets.QStyleOptionSlider
+QtWidgets.QStyleOptionSpinBox = _QtWidgets.QStyleOptionSpinBox
+QtWidgets.QStyleOptionTab = _QtWidgets.QStyleOptionTab
+QtWidgets.QStyleOptionTabBarBase = _QtWidgets.QStyleOptionTabBarBase
+QtWidgets.QStyleOptionTabWidgetFrame = _QtWidgets.QStyleOptionTabWidgetFrame
+QtWidgets.QStyleOptionTitleBar = _QtWidgets.QStyleOptionTitleBar
+QtWidgets.QStyleOptionToolBar = _QtWidgets.QStyleOptionToolBar
+QtWidgets.QStyleOptionToolBox = _QtWidgets.QStyleOptionToolBox
+QtWidgets.QStyleOptionToolButton = _QtWidgets.QStyleOptionToolButton
+QtWidgets.QStyleOptionViewItem = _QtWidgets.QStyleOptionViewItem
+QtWidgets.QStylePainter = _QtWidgets.QStylePainter
+QtWidgets.QStyledItemDelegate = _QtWidgets.QStyledItemDelegate
+QtWidgets.QSwipeGesture = _QtWidgets.QSwipeGesture
+QtWidgets.QSystemTrayIcon = _QtWidgets.QSystemTrayIcon
+QtWidgets.QTabBar = _QtWidgets.QTabBar
+QtWidgets.QTabWidget = _QtWidgets.QTabWidget
+QtWidgets.QTableView = _QtWidgets.QTableView
+QtWidgets.QTableWidget = _QtWidgets.QTableWidget
+QtWidgets.QTableWidgetItem = _QtWidgets.QTableWidgetItem
+QtWidgets.QTableWidgetSelectionRange = _QtWidgets.QTableWidgetSelectionRange
+QtWidgets.QTapAndHoldGesture = _QtWidgets.QTapAndHoldGesture
+QtWidgets.QTapGesture = _QtWidgets.QTapGesture
+QtWidgets.QTextBrowser = _QtWidgets.QTextBrowser
+QtWidgets.QTextEdit = _QtWidgets.QTextEdit
+# QtWidgets.QTileRules = _QtWidgets.QTileRules  # Not in PyQt4
+QtWidgets.QTimeEdit = _QtWidgets.QTimeEdit
+QtWidgets.QToolBar = _QtWidgets.QToolBar
+QtWidgets.QToolBox = _QtWidgets.QToolBox
+QtWidgets.QToolButton = _QtWidgets.QToolButton
+QtWidgets.QToolTip = _QtWidgets.QToolTip
+QtWidgets.QTreeView = _QtWidgets.QTreeView
+QtWidgets.QTreeWidget = _QtWidgets.QTreeWidget
+QtWidgets.QTreeWidgetItem = _QtWidgets.QTreeWidgetItem
+QtWidgets.QTreeWidgetItemIterator = _QtWidgets.QTreeWidgetItemIterator
+QtWidgets.QUndoCommand = _QtWidgets.QUndoCommand
+QtWidgets.QUndoGroup = _QtWidgets.QUndoGroup
+QtWidgets.QUndoStack = _QtWidgets.QUndoStack
+QtWidgets.QUndoView = _QtWidgets.QUndoView
+QtWidgets.QVBoxLayout = _QtWidgets.QVBoxLayout
+QtWidgets.QWhatsThis = _QtWidgets.QWhatsThis
+QtWidgets.QWidget = _QtWidgets.QWidget
+QtWidgets.QWidgetAction = _QtWidgets.QWidgetAction
+QtWidgets.QWidgetItem = _QtWidgets.QWidgetItem
+QtWidgets.QWizard = _QtWidgets.QWizard
+QtWidgets.QWizardPage = _QtWidgets.QWizardPage
+QtWidgets.qApp = _QtWidgets.qApp
 
-    """
 
-    bindings = (_pyside2, _pyqt5, _pyside, _pyqt4)
+# QtCore.ClassInfo = _QtCore.ClassInfo  # Not in PyQt4
+# QtCore.Connection = _QtCore.Connection  # Not in docs?
+# QtCore.MetaFunction = _QtCore.MetaFunction  # Not in PyQt4
+QtCore.QAbstractAnimation = _QtCore.QAbstractAnimation
+QtCore.QAbstractEventDispatcher = _QtCore.QAbstractEventDispatcher
+QtCore.QAbstractItemModel = _QtCore.QAbstractItemModel
+QtCore.QAbstractListModel = _QtCore.QAbstractListModel
+QtCore.QAbstractState = _QtCore.QAbstractState
+QtCore.QAbstractTableModel = _QtCore.QAbstractTableModel
+QtCore.QAbstractTransition = _QtCore.QAbstractTransition
+QtCore.QAnimationGroup = _QtCore.QAnimationGroup
+# QtCore.QBasicMutex = _QtCore.QBasicMutex  # Not in docs?
+QtCore.QBasicTimer = _QtCore.QBasicTimer
+QtCore.QBitArray = _QtCore.QBitArray
+QtCore.QBuffer = _QtCore.QBuffer
+QtCore.QByteArray = _QtCore.QByteArray
+QtCore.QByteArrayMatcher = _QtCore.QByteArrayMatcher
+QtCore.QChildEvent = _QtCore.QChildEvent
+QtCore.QCoreApplication = _QtCore.QCoreApplication
+QtCore.QCryptographicHash = _QtCore.QCryptographicHash
+QtCore.QDataStream = _QtCore.QDataStream
+QtCore.QDate = _QtCore.QDate
+QtCore.QDateTime = _QtCore.QDateTime
+QtCore.QDir = _QtCore.QDir
+QtCore.QDirIterator = _QtCore.QDirIterator
+QtCore.QDynamicPropertyChangeEvent = _QtCore.QDynamicPropertyChangeEvent
+QtCore.QEasingCurve = _QtCore.QEasingCurve
+QtCore.QElapsedTimer = _QtCore.QElapsedTimer
+QtCore.QEvent = _QtCore.QEvent
+QtCore.QEventLoop = _QtCore.QEventLoop
+QtCore.QEventTransition = _QtCore.QEventTransition
+# QtCore.QFactoryInterface = _QtCore.QFactoryInterface  # Not in PyQt4
+QtCore.QFile = _QtCore.QFile
+# QtCore.QFileDevice = _QtCore.QFileDevice
+QtCore.QFileInfo = _QtCore.QFileInfo
+QtCore.QFileSystemWatcher = _QtCore.QFileSystemWatcher
+QtCore.QFinalState = _QtCore.QFinalState
+QtCore.QGenericArgument = _QtCore.QGenericArgument
+QtCore.QGenericReturnArgument = _QtCore.QGenericReturnArgument
+QtCore.QHistoryState = _QtCore.QHistoryState
+QtCore.QIODevice = _QtCore.QIODevice
+# QtCore.QItemSelectionRange = _QtCore.QItemSelectionRange
+# QtCore.QJsonArray = _QtCore.QJsonArray
+# QtCore.QJsonDocument = _QtCore.QJsonDocument
+# QtCore.QJsonParseError = _QtCore.QJsonParseError
+# QtCore.QJsonValue = _QtCore.QJsonValue
+QtCore.QLibraryInfo = _QtCore.QLibraryInfo
+QtCore.QLine = _QtCore.QLine
+QtCore.QLineF = _QtCore.QLineF
+QtCore.QLocale = _QtCore.QLocale
+QtCore.QMargins = _QtCore.QMargins
+# QtCore.QMessageLogContext = _QtCore.QMessageLogContext
+QtCore.QMetaClassInfo = _QtCore.QMetaClassInfo
+QtCore.QMetaEnum = _QtCore.QMetaEnum
+QtCore.QMetaMethod = _QtCore.QMetaMethod
+QtCore.QMetaObject = _QtCore.QMetaObject
+QtCore.QMetaProperty = _QtCore.QMetaProperty
+QtCore.QMimeData = _QtCore.QMimeData
+QtCore.QModelIndex = _QtCore.QModelIndex
+QtCore.QMutex = _QtCore.QMutex
+QtCore.QMutexLocker = _QtCore.QMutexLocker
+QtCore.QObject = _QtCore.QObject
+QtCore.QParallelAnimationGroup = _QtCore.QParallelAnimationGroup
+QtCore.QPauseAnimation = _QtCore.QPauseAnimation
+QtCore.QPersistentModelIndex = _QtCore.QPersistentModelIndex
+QtCore.QPluginLoader = _QtCore.QPluginLoader
+QtCore.QPoint = _QtCore.QPoint
+QtCore.QPointF = _QtCore.QPointF
+QtCore.QProcess = _QtCore.QProcess
+QtCore.QProcessEnvironment = _QtCore.QProcessEnvironment
+QtCore.QPropertyAnimation = _QtCore.QPropertyAnimation
+QtCore.QReadLocker = _QtCore.QReadLocker
+QtCore.QReadWriteLock = _QtCore.QReadWriteLock
+QtCore.QRect = _QtCore.QRect
+QtCore.QRectF = _QtCore.QRectF
+QtCore.QRegExp = _QtCore.QRegExp
+QtCore.QResource = _QtCore.QResource
+QtCore.QRunnable = _QtCore.QRunnable
+QtCore.QSemaphore = _QtCore.QSemaphore
+QtCore.QSequentialAnimationGroup = _QtCore.QSequentialAnimationGroup
+QtCore.QSettings = _QtCore.QSettings
+QtCore.QSignalMapper = _QtCore.QSignalMapper
+QtCore.QSignalTransition = _QtCore.QSignalTransition
+QtCore.QSize = _QtCore.QSize
+QtCore.QSizeF = _QtCore.QSizeF
+QtCore.QSocketNotifier = _QtCore.QSocketNotifier
+QtCore.QState = _QtCore.QState
+QtCore.QStateMachine = _QtCore.QStateMachine
+QtCore.QSysInfo = _QtCore.QSysInfo
+QtCore.QSystemSemaphore = _QtCore.QSystemSemaphore
+# QtCore.QT_TRANSLATE_NOOP = _QtCore.QT_TRANSLATE_NOOP  # Not in PyQt4
+# QtCore.QT_TRANSLATE_NOOP3 = _QtCore.QT_TRANSLATE_NOOP3  # Not in PyQt4
+# QtCore.QT_TRANSLATE_NOOP_UTF8 = _QtCore.QT_TRANSLATE_NOOP_UTF8  # Not in PyQt4
+# QtCore.QT_TR_NOOP = _QtCore.QT_TR_NOOP  # Not in PyQt4
+# QtCore.QT_TR_NOOP_UTF8 = _QtCore.QT_TR_NOOP_UTF8  # Not in PyQt4
+QtCore.QTemporaryFile = _QtCore.QTemporaryFile
+QtCore.QTextBoundaryFinder = _QtCore.QTextBoundaryFinder
+QtCore.QTextCodec = _QtCore.QTextCodec
+QtCore.QTextDecoder = _QtCore.QTextDecoder
+QtCore.QTextEncoder = _QtCore.QTextEncoder
+QtCore.QTextStream = _QtCore.QTextStream
+QtCore.QTextStreamManipulator = _QtCore.QTextStreamManipulator
+QtCore.QThread = _QtCore.QThread
+QtCore.QThreadPool = _QtCore.QThreadPool
+QtCore.QTime = _QtCore.QTime
+QtCore.QTimeLine = _QtCore.QTimeLine
+QtCore.QTimer = _QtCore.QTimer
+QtCore.QTimerEvent = _QtCore.QTimerEvent
+QtCore.QTranslator = _QtCore.QTranslator
+QtCore.QUrl = _QtCore.QUrl
+QtCore.QVariantAnimation = _QtCore.QVariantAnimation
+QtCore.QWaitCondition = _QtCore.QWaitCondition
+QtCore.QWriteLocker = _QtCore.QWriteLocker
+QtCore.QXmlStreamAttribute = _QtCore.QXmlStreamAttribute
+QtCore.QXmlStreamAttributes = _QtCore.QXmlStreamAttributes
+QtCore.QXmlStreamEntityDeclaration = _QtCore.QXmlStreamEntityDeclaration
+QtCore.QXmlStreamEntityResolver = _QtCore.QXmlStreamEntityResolver
+QtCore.QXmlStreamNamespaceDeclaration = _QtCore.QXmlStreamNamespaceDeclaration
+QtCore.QXmlStreamNotationDeclaration = _QtCore.QXmlStreamNotationDeclaration
+QtCore.QXmlStreamReader = _QtCore.QXmlStreamReader
+QtCore.QXmlStreamWriter = _QtCore.QXmlStreamWriter
+QtCore.Qt = _QtCore.Qt
+QtCore.QtCriticalMsg = _QtCore.QtCriticalMsg
+QtCore.QtDebugMsg = _QtCore.QtDebugMsg
+QtCore.QtFatalMsg = _QtCore.QtFatalMsg
+# QtCore.QtInfoMsg = _QtCore.QtInfoMsg  # Not in docs?
+QtCore.QtMsgType = _QtCore.QtMsgType
+QtCore.QtSystemMsg = _QtCore.QtSystemMsg
+QtCore.QtWarningMsg = _QtCore.QtWarningMsg
+# QtCore.SIGNAL = _QtCore.SIGNAL  # Not in PyQt5
+# QtCore.SLOT = _QtCore.SLOT  # Not in PyQt5
+QtCore.qAbs = _QtCore.qAbs
+# QtCore.qAcos = _QtCore.qAcos  # Not in PyQt4
+QtCore.qAddPostRoutine = _QtCore.qAddPostRoutine
+# QtCore.qAsin = _QtCore.qAsin  # Not in PyQt4
+# QtCore.qAtan = _QtCore.qAtan  # Not in PyQt4
+# QtCore.qAtan2 = _QtCore.qAtan2  # Not in PyQt4
+QtCore.qChecksum = _QtCore.qChecksum
+QtCore.qCritical = _QtCore.qCritical
+QtCore.qDebug = _QtCore.qDebug
+# QtCore.qExp = _QtCore.qExp  # Not in PyQt4
+# QtCore.qFabs = _QtCore.qFabs   # Not in PyQt4
+# QtCore.qFastCos = _QtCore.qFastCos  # Not in PyQt4
+# QtCore.qFastSin = _QtCore.qFastSin  # Not in PyQt4
+QtCore.qFatal = _QtCore.qFatal
+QtCore.qFuzzyCompare = _QtCore.qFuzzyCompare
+# QtCore.qFuzzyIsNull = _QtCore.qFuzzyIsNull  # Not in PyQt4
+# QtCore.qInstallMessageHandler = _QtCore.qInstallMessageHandler  # Not in docs?
+QtCore.qIsFinite = _QtCore.qIsFinite
+QtCore.qIsInf = _QtCore.qIsInf
+QtCore.qIsNaN = _QtCore.qIsNaN
+QtCore.qIsNull = _QtCore.qIsNull
+QtCore.qRegisterResourceData = _QtCore.qRegisterResourceData
+# QtCore.qTan = _QtCore.qTan  # Not in PyQt4
+QtCore.qUnregisterResourceData = _QtCore.qUnregisterResourceData
+QtCore.qVersion = _QtCore.qVersion
+QtCore.qWarning = _QtCore.qWarning
+QtCore.qrand = _QtCore.qrand
+QtCore.qsrand = _QtCore.qsrand
+# QtCore.qtTrI = _QtCore.qtTrId  # Not in PyQt4
 
-    if QT_PREFERRED_BINDING:
-        # Internal flag (used in installer)
-        if QT_PREFERRED_BINDING == "None":
-            self.__wrapper_version__ = self.__version__
-            return
 
-        preferred = QT_PREFERRED_BINDING.split(os.pathsep)
-        available = {
-            "PySide2": _pyside2,
-            "PyQt5": _pyqt5,
-            "PySide": _pyside,
-            "PyQt4": _pyqt4
-        }
+"""
 
-        try:
-            bindings = [available[binding] for binding in preferred]
-        except KeyError:
-            raise ImportError(
-                "Available preferred Qt bindings: "
-                "\n".join(preferred)
-            )
+Special case
 
-    for binding in bindings:
-        _log("Trying %s" % binding.__name__, QT_VERBOSE)
+In some bindings, members are either misplaced or renamed.
 
-        try:
-            binding = binding()
+"""
 
-        except ImportError as e:
-            _log(" - ImportError(\"%s\")" % e, QT_VERBOSE)
-            continue
+if "PySide2" == QtCompat.__binding__:
+    QtCore.QAbstractProxyModel = _QtCore.QAbstractProxyModel
+    QtCore.QSortFilterProxyModel = _QtCore.QSortFilterProxyModel
+    QtCore.QStringListModel = _QtGui.QStringListModel
+    QtCore.QItemSelection = _QtCore.QItemSelection
+    QtCore.QItemSelectionModel = _QtCore.QItemSelectionModel
 
-        else:
-            # Reference to this module
-            binding.QtCompat = self
-            binding.__shim__ = self  # DEPRECATED
+if "PyQt5" == QtCompat.__binding__:
+    QtCore.QAbstractProxyModel = _QtCore.QAbstractProxyModel
+    QtCore.QSortFilterProxyModel = _QtCore.QSortFilterProxyModel
+    QtCore.QStringListModel = _QtCore.QStringListModel
+    QtCore.QItemSelection = _QtCore.QItemSelection
+    QtCore.QItemSelectionModel = _QtCore.QItemSelectionModel
 
-            sys.modules.update({
-                __name__: binding,
+if "PySide" == QtCompat.__binding__:
+    QtCore.QAbstractProxyModel = _QtGui.QAbstractProxyModel
+    QtCore.QSortFilterProxyModel = _QtGui.QSortFilterProxyModel
+    QtCore.QStringListModel = _QtGui.QStringListModel
+    QtCore.QItemSelection = _QtGui.QItemSelection
+    QtCore.QItemSelectionModel = _QtGui.QItemSelectionModel
 
-                # Fix #133, `from Qt.QtWidgets import QPushButton`
-                __name__ + ".QtWidgets": binding.QtWidgets,
+if "PyQt4" == QtCompat.__binding__:
+    QtCore.QAbstractProxyModel = _QtGui.QAbstractProxyModel
+    QtCore.QSortFilterProxyModel = _QtGui.QSortFilterProxyModel
+    QtCore.QItemSelection = _QtGui.QItemSelection
+    QtCore.QStringListModel = _QtGui.QStringListModel
+    QtCore.QItemSelectionModel = _QtGui.QItemSelectionModel
 
-                # Fix #158 `import Qt.QtCore;Qt.QtCore.Signal`
-                __name__ + ".QtCore": binding.QtCore,
-                __name__ + ".QtGui": binding.QtGui,
+if "PyQt" in QtCompat.__binding__:
+    QtCore.Property = _QtCore.pyqtProperty
+    QtCore.Signal = _QtCore.pyqtSignal
+    QtCore.Slot = _QtCore.pyqtSlot
 
-            })
-
-            return
-
-    # If not binding were found, throw this error
-    raise ImportError("No Qt binding were found.")
+else:
+    QtCore.Property = _QtCore.Property
+    QtCore.Signal = _QtCore.Signal
+    QtCore.Slot = _QtCore.Slot
 
 
-def _maintain_backwards_compatibility(binding):
-    """Add members found in prior versions up till the next major release
-
-    These members are to be considered deprecated. When a new major
-    release is made, these members are removed.
-
-    """
-
-    for member in ("__binding__",
-                   "__binding_version__",
-                   "__qt_version__",
-                   "__added__",
-                   "__remapped__",
-                   "__modified__",
-                   "convert",
-                   "load_ui",
-                   "translate"):
-        setattr(binding, member, getattr(self, member))
-        self.__added__.append(member)
-
-    setattr(binding, "__wrapper_version__", self.__version__)
-    self.__added__.append("__wrapper_version__")
-
-
-cli(sys.argv[1:]) if __name__ == "__main__" else init()
+# Hide internal members from external use.
+del(_QtCore)
+del(_QtGui)
+del(_QtWidgets)
+del(_bindings)
+del(_binding)
+del(_found_finding)

--- a/README.md
+++ b/README.md
@@ -89,14 +89,10 @@ All members of `Qt` stem directly from those available via PySide2, along with t
 
 | Attribute               | Returns     | Description
 |:------------------------|:------------|:------------
+| `__version__`           | `str`       | Version of this project
 | `__binding__`           | `str`       | A string reference to binding currently in use
 | `__qt_version__`        | `str`       | Reference to version of Qt, such as Qt 5.6.1
 | `__binding_version__`   | `str`       | Reference to version of binding, such as PySide 1.2.6
-| `__wrapper_version__`   | `str`       | Version of this project
-| `__added__`             | `list(str)` | All unique members of Qt.py
-| `__remapped__`          | `list(str)` | Members copied from elsewhere, such as QtGui -> QtWidgets
-| `__modified__`          | `list(str)` | Existing members modified in some way
-| `__shim__`              | `module`    | Reference to original Qt.py Python module
 | `load_ui(fname=str)`    | `QObject`   | Minimal wrapper of PyQt4.loadUi and PySide equivalent
 | `translate(...)`        | `function`  | Compatibility wrapper around [QCoreApplication.translate][]
 | `setSectionResizeMode()`| `method`    | Compatibility wrapper around [QAbstractItemView.setSectionResizeMode][]
@@ -111,6 +107,28 @@ All members of `Qt` stem directly from those available via PySide2, along with t
 >>> QtCompat.__binding__
 'PyQt5'
 ```
+
+<br>
+
+##### Environment Variables
+
+These are the publicly facing environment variables that in one way or another affect the way Qt.py is run.
+
+| Variable             | Type  | Description
+|:---------------------|:------|:----------
+| QT_PREFFERED_BINDING | str   | Override order and content of binding to try.
+| QT_STRICT            | bool  | Enforce compatibility with other bindings.
+| QT_VERBOSE           | bool  | Be a little more chatty when importing Qt
+
+<br>
+
+##### Strict Mode
+
+Enforce compatibility with all bindings.
+
+Use this to ensure that your program will run identically on all bindings.
+
+When enabling `QT_STRICT`, Qt.py becomes a subset of PySide2. All members are guaranteed to exist across all bindings, meaning many will be missing. Including QtQml and QtQuick modules.
 
 <br>
 
@@ -221,7 +239,9 @@ PySide2.QtCore.QStringListModel = PySide2.QtGui.QStringListModel
 
 **Portability**
 
-Qt.py does not hide members from the original binding. This can be problematic if, for example, you accidentally use a member that only exists PyQt5 and later try running your software with a different binding.
+Qt.py has two modes - loose and strict.
+
+Loose means Qt.py does not hide members from the original binding. This can be problematic if, for example, you accidentally use a member that only exists PyQt5 and later try running your software with a different binding.
 
 ```python
 from Qt import QtCore
@@ -238,37 +258,16 @@ from Qt import QtCore
 from PyQt4 import QtGui
 ```
 
+Strict on the other hand only exposes members that are guaranteed to work identically across all bindings. This mode is ideal if you are looking for the most cross-compatible experience and you would like your software to run on all bindings.
+
+```python
+from Qt import QtGui
+assert not hasattr(QtGui, "QWidget")
+```
+
 **Caveats**
 
 There are cases where Qt.py is not handling incompatibility issues. Please see [`CAVEATS.md`](CAVEATS.md) for more information.
-
-<br>
-<br>
-<br>
-
-### How it works
-
-Once you import Qt.py, Qt.py replaces itself with the most desirable binding on your platform, or throws an `ImportError` if none are available.
-
-```python
->>> import Qt
->>> print(Qt)
-<module 'PyQt5' from 'C:\Python27\lib\site-packages\PyQt5\__init__.pyc'>
-```
-
-Here's an example of how this works.
-
-**Qt.py**
-
-```python
-import sys
-import PyQt5
-
-# Replace myself PyQt5
-sys.modules["Qt"] = PyQt5
-```
-
-Once imported, it is as though your application was importing whichever binding was chosen and Qt.py never existed.
 
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Use this to ensure that your program will run identically on all bindings.
 
 When enabling `QT_STRICT`, Qt.py becomes a subset of PySide2. All members are guaranteed to exist across all bindings, meaning many will be missing. Including QtQml and QtQuick modules.
 
-Strict mode follows the [VFX Platform](http://www.vfxplatform.com/) to determine which version of PySide2 to use for reference. Currently version if 2.0.0.
+Strict mode follows the [VFX Platform](http://www.vfxplatform.com/) to determine which version of PySide2 to use for reference. Currently version is 2.0.0.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Use this to ensure that your program will run identically on all bindings.
 
 When enabling `QT_STRICT`, Qt.py becomes a subset of PySide2. All members are guaranteed to exist across all bindings, meaning many will be missing. Including QtQml and QtQuick modules.
 
+Strict mode follows the [VFX Platform](http://www.vfxplatform.com/) to determine which version of PySide2 to use for reference. Currently version if 2.0.0.
+
 <br>
 
 ##### Branch binding-specific code

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ app.exec_()
 
 ### Documentation
 
-All members of `Qt` stem directly from those available via PySide2, along with these additional members, accessible via `Qt.QtCompat`.
+All members of `Qt` stem directly from those available via PySide2, along with these additional members.
 
 | Attribute               | Returns     | Description
 |:------------------------|:------------|:------------
@@ -93,6 +93,19 @@ All members of `Qt` stem directly from those available via PySide2, along with t
 | `__binding__`           | `str`       | A string reference to binding currently in use
 | `__qt_version__`        | `str`       | Reference to version of Qt, such as Qt 5.6.1
 | `__binding_version__`   | `str`       | Reference to version of binding, such as PySide 1.2.6
+
+**Example**
+
+```python
+>>> from Qt import __binding__
+>>> __binding__
+'PyQt5'
+```
+
+Qt.py also provides compatibility wrappers for critical functionality that differs across bindings, these can be found in the added `QtCompat` submodule.
+
+| Attribute               | Returns     | Description
+|:------------------------|:------------|:------------
 | `load_ui(fname=str)`    | `QObject`   | Minimal wrapper of PyQt4.loadUi and PySide equivalent
 | `translate(...)`        | `function`  | Compatibility wrapper around [QCoreApplication.translate][]
 | `setSectionResizeMode()`| `method`    | Compatibility wrapper around [QAbstractItemView.setSectionResizeMode][]
@@ -104,8 +117,7 @@ All members of `Qt` stem directly from those available via PySide2, along with t
 
 ```python
 >>> from Qt import QtCompat
->>> QtCompat.__binding__
-'PyQt5'
+>>> QtCompat.setSectionResizeMode
 ```
 
 <br>
@@ -134,7 +146,7 @@ The version of PySide2 used as reference is the one specified on [VFX Platform](
 Some bindings offer features not available in others, you can use `__binding__` to capture those.
 
 ```python
-if "PySide" in QtCompat.__binding__:
+if "PySide" in __binding__:
   do_pyside_stuff()
 ```
 
@@ -147,7 +159,7 @@ If your system has multiple choices where one or more is preferred, you can over
 ```bash
 $ set QT_PREFERRED_BINDING=PyQt5  # Windows
 $ export QT_PREFERRED_BINDING=PyQt5  # Unix/OSX
-$ python -c "from Qt import QtCompat;print(QtCompat.__binding__)"
+$ python -c "import Qt;print(Qt.__binding__)"
 PyQt5
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Qt.py
 
-Qt.py enables you to write software that dynamically chooses the most desireable bindings based on what's available, including PySide2, PyQt5, PySide and PyQt4; in that (configurable) order (see below).
+Qt.py enables you to write software that runs on any of the 4 supported bindings - PySide2, PyQt5, PySide and PyQt4.
 
 **Guides**
 
@@ -31,15 +31,15 @@ Qt.py enables you to write software that dynamically chooses the most desireable
 
 ### Project goals
 
-Write for PySide2, run in any binding.
+Write once, run in any binding.
 
 Qt.py was born in the film and visual effects industry to address the growing need for software capable of running with more than one flavor of the Qt bindings for Python - PySide, PySide2, PyQt4 and PyQt5.
 
 | Goal                                 | Description
 |:-------------------------------------|:---------------
-| *Support co-existence* | Qt.py should not affect other bindings running in same interpreter session.
-| *Build for one, run with all* | Code written with Qt.py should run on any binding.
-| *Explicit is better than implicit* | Differences between bindings should be visible to you.
+| *Support co-existence*               | Qt.py should not affect other bindings running in same interpreter session.
+| *Build for one, run with all*        | Code written with Qt.py should run on any binding.
+| *Explicit is better than implicit*   | Differences between bindings should be visible to you.
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for more details.
 
@@ -117,20 +117,15 @@ These are the publicly facing environment variables that in one way or another a
 | Variable             | Type  | Description
 |:---------------------|:------|:----------
 | QT_PREFFERED_BINDING | str   | Override order and content of binding to try.
-| QT_STRICT            | bool  | Enforce compatibility with other bindings.
-| QT_VERBOSE           | bool  | Be a little more chatty when importing Qt
+| QT_VERBOSE           | bool  | Be a little more chatty about what's going on with Qt.py
 
 <br>
 
-##### Strict Mode
+##### Subset
 
-Enforce compatibility with all bindings.
+Members of Qt.py is a subset of PySide2. Which means for a member to be made accessible via Qt.py, it will need to (1) be accessible via PySide2 and (2) each of the other supported bindings. This excludes large portions of the Qt framework, including the newly added QtQml and QtQuick modules but guarantees that anything you develop with Qt.py will work identically on any binding - PySide, PySide2, PyQt4 and PyQt5.
 
-Use this to ensure that your program will run identically on all bindings.
-
-When enabling `QT_STRICT`, Qt.py becomes a subset of PySide2. All members are guaranteed to exist across all bindings, meaning many will be missing. Including QtQml and QtQuick modules.
-
-Strict mode follows the [VFX Platform](http://www.vfxplatform.com/) to determine which version of PySide2 to use for reference. Currently version is 2.0.0.
+The version of PySide2 used as reference is the one specified on [VFX Platform](http://www.vfxplatform.com/). Currently version is 2.0.0.
 
 <br>
 
@@ -239,34 +234,6 @@ PyQt5.Slot = PyQt5.pyqtSlot
 PySide2.QtCore.QStringListModel = PySide2.QtGui.QStringListModel
 ```
 
-**Portability**
-
-Qt.py has two modes - loose and strict.
-
-Loose means Qt.py does not hide members from the original binding. This can be problematic if, for example, you accidentally use a member that only exists PyQt5 and later try running your software with a different binding.
-
-```python
-from Qt import QtCore
-
-# Incompatible with PySide
-signal = QtCore.pyqtSignal()
-```
-
-But it enables use of Qt.py as a helper library, in conjunction with an existing binding, simplifying the transition of an existing project from a particular binding.
-
-```python
-# This is ok
-from Qt import QtCore
-from PyQt4 import QtGui
-```
-
-Strict on the other hand only exposes members that are guaranteed to work identically across all bindings. This mode is ideal if you are looking for the most cross-compatible experience and you would like your software to run on all bindings.
-
-```python
-from Qt import QtGui
-assert not hasattr(QtGui, "QWidget")
-```
-
 **Caveats**
 
 There are cases where Qt.py is not handling incompatibility issues. Please see [`CAVEATS.md`](CAVEATS.md) for more information.
@@ -304,6 +271,7 @@ Send us a pull-request with your studio here.
 - [Fido](http://fido.se/)
 - [Bläck](http://www.blackstudios.se/)
 - [CGRU](http://cgru.info/)
+- [MPC](http://www.moving-picture.com)
 
 Presented at Siggraph 2016, BOF!
 
@@ -377,8 +345,8 @@ Tests that are written at module level are run four times - once per binding - w
 
 ```python
 if binding("PyQt4"):
-	def test_something_related_to_pyqt4():
-		pass
+    def test_something_related_to_pyqt4():
+        pass
 ```
 
 **Running tests**

--- a/build_membership.py
+++ b/build_membership.py
@@ -68,8 +68,13 @@ def build_tests():
 import os
 import json
 
+
 with open("reference_members.json") as f:
     reference_members = json.load(f)
+
+# Only bother checking strict mode, as it is
+# the only mode that modifies membership in any way.
+os.environ["QT_STRICT"] = "1"
 
 excluded = {excluded}
 
@@ -78,6 +83,10 @@ excluded = {excluded}
     test = """\
 def test_{binding}_members():
     os.environ["QT_PREFERRED_BINDING"] = "{Binding}"
+
+    # Initialise Qt.py, this is especially important for PyQt4
+    # which sets sip to 2.0 upon loading Qt.py
+    import Qt
 
     if "PyQt" in "{Binding}":
         # PyQt4 and 5 performs some magic here
@@ -93,6 +102,7 @@ def test_{binding}_members():
         for missing in ("QtWidgets",
                         "QtXml",
                         "QtHelp",
+                        "QtNetwork",
                         "QtPrintSupport"):
             __all__.append(missing)
 
@@ -252,36 +262,8 @@ excluded = {
     ],
 
     "QtNetwork": [
-        # missing from PyQt4
+        # missing from Qt 4
         "QIPv6Address",
-
-        # missing from PySide
-        "QAbstractNetworkCache",
-        "QAbstractSocket",
-        "QAuthenticator",
-        "QHostAddress",
-        "QHostInfo",
-        "QLocalServer",
-        "QLocalSocket",
-        "QNetworkAccessManager",
-        "QNetworkAddressEntry",
-        "QNetworkCacheMetaData",
-        "QNetworkConfiguration",
-        "QNetworkConfigurationManager",
-        "QNetworkCookie",
-        "QNetworkCookieJar",
-        "QNetworkDiskCache",
-        "QNetworkInterface",
-        "QNetworkProxy",
-        "QNetworkProxyFactory",
-        "QNetworkProxyQuery",
-        "QNetworkReply",
-        "QNetworkRequest",
-        "QNetworkSession",
-        "QSsl",
-        "QTcpServer",
-        "QTcpSocket",
-        "QUdpSocket",
     ],
 
     "QtPrintSupport": [

--- a/build_membership.py
+++ b/build_membership.py
@@ -203,6 +203,8 @@ excluded = {
 
         # missing from all bindings
         "QFileSelector",
+        "QMimeDatabase",
+        "QMimeType",
 
         # missing from PyQt5
         "SIGNAL",

--- a/build_membership.py
+++ b/build_membership.py
@@ -201,6 +201,9 @@ excluded = {
         "qTan",
         "qtTrId",
 
+        # missing from all bindings
+        "QFileSelector",
+
         # missing from PyQt5
         "SIGNAL",
         "SLOT",
@@ -225,6 +228,15 @@ excluded = {
         "QMatrix",
         "QPyTextObject",
         "QStringListModel",
+
+        # missing from all bindings
+        "QAccessible",
+        "QAccessibleInterface",
+        "QExposeEvent",
+        "QOpenGLContext",
+        "QOpenGLFramebufferObject",
+        "QOpenGLShader",
+        "QScreen",
     ],
 
     "QtWebKit": [

--- a/build_membership.py
+++ b/build_membership.py
@@ -83,7 +83,7 @@ def test_{binding}_members():
         # PyQt4 and 5 performs some magic here
         # that must take place before attempting
         # to import with wildcard.
-        from Qt import Qt as _
+        from {Binding} import Qt as _
 
     if "PySide2" == "{Binding}":
         # PySide2, as of this writing, doesn't include
@@ -167,6 +167,9 @@ excluded = {
         "QMessageLogContext",
         "QtInfoMsg",
         "qInstallMessageHandler",
+        "QT_TRANSLATE_NOOP",
+        "QT_TR_NOOP",
+        "QT_TR_NOOP_UTF8",
 
         # missing from PyQt4
         "ClassInfo",
@@ -204,6 +207,8 @@ excluded = {
         "QSurfaceFormat",
         "QTouchDevice",
         "QWindow",  # (2) unique to Qt 5
+        "QTouchEvent",  # (2) unique to Qt 5
+        "qRgba",  # (2) unique to Qt 5
 
         # missing from PyQt4
         "QAccessibleEvent",
@@ -252,6 +257,34 @@ excluded = {
     "QtNetwork": [
         # missing from PyQt4
         "QIPv6Address",
+
+        # missing from PySide
+        "QAbstractNetworkCache",
+        "QAbstractSocket",
+        "QAuthenticator",
+        "QHostAddress",
+        "QHostInfo",
+        "QLocalServer",
+        "QLocalSocket",
+        "QNetworkAccessManager",
+        "QNetworkAddressEntry",
+        "QNetworkCacheMetaData",
+        "QNetworkConfiguration",
+        "QNetworkConfigurationManager",
+        "QNetworkCookie",
+        "QNetworkCookieJar",
+        "QNetworkDiskCache",
+        "QNetworkInterface",
+        "QNetworkProxy",
+        "QNetworkProxyFactory",
+        "QNetworkProxyQuery",
+        "QNetworkReply",
+        "QNetworkRequest",
+        "QNetworkSession",
+        "QSsl",
+        "QTcpServer",
+        "QTcpSocket",
+        "QUdpSocket",
     ],
 
     "QtPrintSupport": [
@@ -325,6 +358,10 @@ excluded = {
         "QXmlSimpleReader",
     ],
 
+    "QtTest": [
+        # missing from PySide
+        "QTest",
+    ],
 }
 
 if __name__ == '__main__':

--- a/build_membership.py
+++ b/build_membership.py
@@ -99,9 +99,6 @@ def test_{binding}_members():
     from Qt import *
 
     if "PySide" == "{Binding}":
-        # Qt 4 bindings do not include QtWidgets
-        # in their __all__ list. And who knows what else.
-        #
         # TODO: This needs a more robust implementation.
         from Qt import QtWidgets
 
@@ -306,6 +303,8 @@ excluded = {
         # PyQt5
         "QGraphicsItemAnimation",
         "QTileRules",
+
+        "qApp",  # See Issue #171
     ],
 
     "QtHelp": [

--- a/examples/load_ui/baseinstance1.py
+++ b/examples/load_ui/baseinstance1.py
@@ -4,7 +4,7 @@ import os
 # Set preferred binding
 os.environ['QT_PREFERRED_BINDING'] = os.pathsep.join(['PySide', 'PyQt4'])
 
-from Qt import QtWidgets, load_ui
+from Qt import QtWidgets, QtCompat
 
 
 def setup_ui(uifile, base_instance=None):
@@ -18,7 +18,7 @@ def setup_ui(uifile, base_instance=None):
         QWidget: the base instance
 
     """
-    ui = load_ui(uifile)  # Qt.py mapped function
+    ui = QtCompat.load_ui(uifile)  # Qt.py mapped function
     if not base_instance:
         return ui
     else:
@@ -37,7 +37,7 @@ class MainWindow(QtWidgets.QWidget):
 
 
 def test():
-    """Example: load_ui with setup_ui wrapper"""
+    """Example: QtCompat.load_ui with setup_ui wrapper"""
     working_directory = os.path.dirname(__file__)
     os.chdir(working_directory)
 

--- a/examples/load_ui/baseinstance2.py
+++ b/examples/load_ui/baseinstance2.py
@@ -4,7 +4,7 @@ import os
 # Set preferred binding, or Qt.py tests will fail which doesn't have pysideuic
 os.environ['QT_PREFERRED_BINDING'] = 'PyQt4'
 
-from Qt import QtWidgets, QtCompat
+from Qt import QtWidgets, __binding__
 
 
 def load_ui_type(uifile):
@@ -100,10 +100,10 @@ def load_ui_wrapper(uifile, base_instance=None):
         function: pyside_load_ui or uic.loadUi
 
     """
-    if 'PySide' in QtCompat.__binding__:
+    if 'PySide' in __binding__:
         return pyside_load_ui(uifile, base_instance)
-    elif 'PyQt' in QtCompat.__binding__:
-        uic = __import__(QtCompat.__binding__ + ".uic").uic
+    elif 'PyQt' in __binding__:
+        uic = __import__(__binding__ + ".uic").uic
         return uic.loadUi(uifile, base_instance)
 
 

--- a/examples/load_ui/baseinstance2.py
+++ b/examples/load_ui/baseinstance2.py
@@ -4,8 +4,7 @@ import os
 # Set preferred binding, or Qt.py tests will fail which doesn't have pysideuic
 os.environ['QT_PREFERRED_BINDING'] = 'PyQt4'
 
-from Qt import QtWidgets
-from Qt import __binding__
+from Qt import QtWidgets, QtCompat
 
 
 def load_ui_type(uifile):
@@ -101,10 +100,10 @@ def load_ui_wrapper(uifile, base_instance=None):
         function: pyside_load_ui or uic.loadUi
 
     """
-    if 'PySide' in __binding__:
+    if 'PySide' in QtCompat.__binding__:
         return pyside_load_ui(uifile, base_instance)
-    elif 'PyQt' in __binding__:
-        from Qt import uic
+    elif 'PyQt' in QtCompat.__binding__:
+        uic = __import__(QtCompat.__binding__ + ".uic").uic
         return uic.loadUi(uifile, base_instance)
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup
 
 os.environ["QT_PREFERRED_BINDING"] = "None"
-version = __import__("Qt").__wrapper_version__
+version = __import__("Qt").__version__
 
 
 classifiers = [

--- a/tests.py
+++ b/tests.py
@@ -185,8 +185,8 @@ class Ui_uic(object):
             Qt.QtCompat.translate("uic", "NOT Ok", None, -1))
 """.split("\n")
 
-    import Qt
-    assert Qt.convert(before) == after, after
+    from Qt import QtCompat
+    assert QtCompat._convert(before) == after, after
 
 
 def test_convert_idempotency():
@@ -222,12 +222,12 @@ class Ui_uic(object):
     from Qt import QtCompat
 
     os.chdir(self.tempdir)
-    QtCompat.cli(args=["--convert", "idempotency.py"])
+    QtCompat._cli(args=["--convert", "idempotency.py"])
 
     with open(fname) as f:
         assert f.read() == after
 
-    QtCompat.cli(args=["--convert", "idempotency.py"])
+    QtCompat._cli(args=["--convert", "idempotency.py"])
 
     with open(fname) as f:
         assert f.read() == after
@@ -243,62 +243,11 @@ def test_convert_backup():
     from Qt import QtCompat
 
     os.chdir(self.tempdir)
-    QtCompat.cli(args=["--convert", "idempotency.py"])
+    QtCompat._cli(args=["--convert", "idempotency.py"])
 
     assert os.path.exists(
         os.path.join(self.tempdir, "%s_backup%s" % os.path.splitext(fname))
     )
-
-
-def test_meta_add():
-    """Qt._add() appends to __added__"""
-    from Qt import QtCompat
-
-    module = imp.new_module("QtMock")
-
-    QtCompat._add(module, "MyAttr", None)
-
-    assert "MyAttr" in QtCompat.__added__, QtCompat.__added__
-    assert "MyAttr" not in QtCompat.__remapped__
-    assert "MyAttr" not in QtCompat.__modified__
-
-
-def test_meta_remap():
-    """Qt._remap() appends to __modified__"""
-    from Qt import QtCompat
-
-    module = imp.new_module("QtMock")
-
-    QtCompat._remap(module, "MyAttr", None)
-
-    assert "MyAttr" not in QtCompat.__added__, QtCompat.__added__
-    assert "MyAttr" in QtCompat.__remapped__
-    assert "MyAttr" not in QtCompat.__modified__
-
-
-def test_meta_remap_existing():
-    """Qt._remap() of existing member throws an exception"""
-    from Qt import QtCompat
-
-    module = imp.new_module("QtMock")
-    module.MyAttr = None
-
-    assert_raises(AttributeError, QtCompat._remap, module, "MyAttr", None)
-
-
-def test_meta_force_remap_existing():
-    """Unsafe Qt._remap() of existing member adds to modified"""
-    from Qt import QtCompat
-
-    module = imp.new_module("QtMock")
-    module.MyAttr = 123
-
-    QtCompat._remap(module, "MyAttr", None, safe=False)
-
-    assert "MyAttr" in QtCompat.__remapped__, QtCompat.__remapped__
-    assert "MyAttr" not in QtCompat.__added__
-    assert "MyAttr" in QtCompat.__modified__
-    assert module.MyAttr is None, module.MyAttr
 
 
 def test_import_from_qtwidgets():

--- a/tests.py
+++ b/tests.py
@@ -287,13 +287,13 @@ def test_translate_arguments():
 
 
 def test_binding_and_qt_version():
-    """QtCompat's __binding_version__ and __qt_version__ populated"""
+    """Qt's __binding_version__ and __qt_version__ populated"""
 
-    from Qt import QtCompat
+    import Qt
 
-    assert QtCompat.__binding_version__ != "0.0.0", ("Binding version was not "
-                                                     "populated")
-    assert QtCompat.__qt_version__ != "0.0.0", ("Qt version was not populated")
+    assert Qt.__binding_version__ != "0.0.0", ("Binding version was not "
+                                               "populated")
+    assert Qt.__qt_version__ != "0.0.0", ("Qt version was not populated")
 
 
 def test_strict():
@@ -315,10 +315,10 @@ def test_cli():
 if binding("PyQt4"):
     def test_preferred_pyqt4():
         """QT_PREFERRED_BINDING = PyQt4 properly forces the binding"""
-        from Qt import QtCompat
-        assert QtCompat.__binding__ == "PyQt4", (
+        import Qt
+        assert Qt.__binding__ == "PyQt4", (
             "PyQt4 should have been picked, "
-            "instead got %s" % QtCompat.__binding__)
+            "instead got %s" % Qt.__binding__)
 
     def test_sip_api_qtpy():
         """Preferred binding PyQt4 should have sip version 2"""
@@ -342,28 +342,28 @@ if binding("PyQt4"):
 if binding("PyQt5"):
     def test_preferred_pyqt5():
         """QT_PREFERRED_BINDING = PyQt5 properly forces the binding"""
-        from Qt import QtCompat
-        assert QtCompat.__binding__ == "PyQt5", (
+        import Qt
+        assert Qt.__binding__ == "PyQt5", (
             "PyQt5 should have been picked, "
-            "instead got %s" % QtCompat.__binding__)
+            "instead got %s" % Qt.__binding__)
 
 
 if binding("PySide"):
     def test_preferred_pyside():
         """QT_PREFERRED_BINDING = PySide properly forces the binding"""
-        from Qt import QtCompat
-        assert QtCompat.__binding__ == "PySide", (
+        import Qt
+        assert Qt.__binding__ == "PySide", (
             "PySide should have been picked, "
-            "instead got %s" % QtCompat.__binding__)
+            "instead got %s" % Qt.__binding__)
 
 
 if binding("PySide2"):
     def test_preferred_pyside2():
         """QT_PREFERRED_BINDING = PySide2 properly forces the binding"""
-        from Qt import QtCompat
-        assert QtCompat.__binding__ == "PySide2", (
+        import Qt
+        assert Qt.__binding__ == "PySide2", (
             "PySide2 should have been picked, "
-            "instead got %s" % QtCompat.__binding__)
+            "instead got %s" % Qt.__binding__)
 
     def test_coexistence():
         """Qt.py may be use alongside the actual binding"""
@@ -386,7 +386,7 @@ if binding("PySide") or binding("PySide2"):
         os.environ["QT_PREFERRED_BINDING"] = os.pathsep.join(
             ["PySide", "PySide2"])
 
-        from Qt import QtCompat
-        assert QtCompat.__binding__ == "PySide", (
+        import Qt
+        assert Qt.__binding__ == "PySide", (
             "PySide should have been picked, "
-            "instead got %s" % QtCompat.__binding__)
+            "instead got %s" % Qt.__binding__)

--- a/tests.py
+++ b/tests.py
@@ -303,6 +303,15 @@ def test_strict():
     assert not hasattr(QtGui, "QWidget")
 
 
+def test_cli():
+    """Qt.py is available from the command-line"""
+    os.environ.pop("QT_VERBOSE")
+    popen = subprocess.Popen([sys.executable, "Qt.py", "--help"],
+                             stdout=subprocess.PIPE)
+    out, err = popen.communicate()
+    assert out.startswith("usage: Qt.py")
+
+
 if binding("PyQt4"):
     def test_preferred_pyqt4():
         """QT_PREFERRED_BINDING = PyQt4 properly forces the binding"""

--- a/tests.py
+++ b/tests.py
@@ -88,9 +88,9 @@ def test_load_ui_returntype():
     """load_ui returns an instance of QObject"""
 
     import sys
-    from Qt import QtWidgets, QtCore, load_ui
+    from Qt import QtWidgets, QtCore, QtCompat
     app = QtWidgets.QApplication(sys.argv)
-    obj = load_ui(self.ui_qwidget)
+    obj = QtCompat.load_ui(self.ui_qwidget)
     assert isinstance(obj, QtCore.QObject)
     app.exit()
 
@@ -350,18 +350,19 @@ def test_binding_and_qt_version():
 if binding("PyQt4"):
     def test_preferred_pyqt4():
         """QT_PREFERRED_BINDING = PyQt4 properly forces the binding"""
-        import Qt
-        assert Qt.__name__ == "PyQt4", ("PyQt4 should have been picked, "
-                                        "instead got %s" % Qt)
+        from Qt import QtCompat
+        assert QtCompat.__binding__ == "PyQt4", (
+            "PyQt4 should have been picked, "
+            "instead got %s" % QtCompat.__binding__)
 
     def test_sip_api_qtpy():
         """Preferred binding PyQt4 should have sip version 2"""
 
         __import__("Qt")  # Bypass linter warning
         import sip
-        assert sip.getapi("QString") == 2, ("PyQt4 API version should be 2, "
-                                            "instead is %s"
-                                            % sip.getapi("QString"))
+        assert sip.getapi("QString") == 2, (
+            "PyQt4 API version should be 2, "
+            "instead is %s" % sip.getapi("QString"))
 
     if PYTHON == 2:
         def test_sip_api_already_set():
@@ -376,25 +377,28 @@ if binding("PyQt4"):
 if binding("PyQt5"):
     def test_preferred_pyqt5():
         """QT_PREFERRED_BINDING = PyQt5 properly forces the binding"""
-        import Qt
-        assert Qt.__name__ == "PyQt5", ("PyQt5 should have been picked, "
-                                        "instead got %s" % Qt)
+        from Qt import QtCompat
+        assert QtCompat.__binding__ == "PyQt5", (
+            "PyQt5 should have been picked, "
+            "instead got %s" % QtCompat.__binding__)
 
 
 if binding("PySide"):
     def test_preferred_pyside():
         """QT_PREFERRED_BINDING = PySide properly forces the binding"""
-        import Qt
-        assert Qt.__name__ == "PySide", ("PySide should have been picked, "
-                                         "instead got %s" % Qt)
+        from Qt import QtCompat
+        assert QtCompat.__binding__ == "PySide", (
+            "PySide should have been picked, "
+            "instead got %s" % QtCompat.__binding__)
 
 
 if binding("PySide2"):
     def test_preferred_pyside2():
         """QT_PREFERRED_BINDING = PySide2 properly forces the binding"""
-        import Qt
-        assert Qt.__name__ == "PySide2", ("PySide2 should have been picked, "
-                                          "instead got %s" % Qt)
+        from Qt import QtCompat
+        assert QtCompat.__binding__ == "PySide2", (
+            "PySide2 should have been picked, "
+            "instead got %s" % QtCompat.__binding__)
 
     def test_coexistence():
         """Qt.py may be use alongside the actual binding"""
@@ -417,6 +421,7 @@ if binding("PySide") or binding("PySide2"):
         os.environ["QT_PREFERRED_BINDING"] = os.pathsep.join(
             ["PySide", "PySide2"])
 
-        import Qt
-        assert Qt.__name__ == "PySide", ("PySide should have been picked, "
-                                         "instead got %s" % Qt)
+        from Qt import QtCompat
+        assert QtCompat.__binding__ == "PySide", (
+            "PySide should have been picked, "
+            "instead got %s" % QtCompat.__binding__)

--- a/tests.py
+++ b/tests.py
@@ -309,7 +309,7 @@ def test_cli():
     popen = subprocess.Popen([sys.executable, "Qt.py", "--help"],
                              stdout=subprocess.PIPE)
     out, err = popen.communicate()
-    assert out.startswith("usage: Qt.py")
+    assert out.startswith(b"usage: Qt.py")
 
 
 if binding("PyQt4"):

--- a/tests.py
+++ b/tests.py
@@ -296,6 +296,13 @@ def test_binding_and_qt_version():
     assert QtCompat.__qt_version__ != "0.0.0", ("Qt version was not populated")
 
 
+def test_strict():
+    """QT_STRICT exposes only a subset of PySide2"""
+    os.environ["QT_STRICT"] = "1"
+    from Qt import QtGui
+    assert not hasattr(QtGui, "QWidget")
+
+
 if binding("PyQt4"):
     def test_preferred_pyqt4():
         """QT_PREFERRED_BINDING = PyQt4 properly forces the binding"""


### PR DESCRIPTION
Hi all,

This is a first pass on #152, a strict enforcement of the PySide2 API.

It's a suggestion, so do not merge unless we've talked it through and are all happy with it.

Things to note:

1. Qt.py is now **twice as large** (from 446 to 889 lines) as before, due to explicitly specifying each member.
1. This *will* break existing code that uses members other than those found in PySide2.
1. A number of inconsistencies were immediately found (and fixed) in tests, CAVEATS and examples. This is a good thing! Have a look.
1. QtWebKit was excluded as it is not guaranteed to exist in PyQt4 and 5 (it's an optional add-on).

On (1), this isn't necessarily a disadvantage; it does make the code trivially simple and require close-to-zero understanding of the overall code to make contributions. Such as adding missing members, or members that become available (as PySide2 is still under active development).

### Discussion

I personally think this is the right way forwards, but it does mean less code will run on it. At the moment, Qt.py is rather forgiving but then of course punishes you secretly further on as you attempt to run it on other bindings.

I could imagine we either make this leap, force users to conform to a strict subset of PySide2, or install a switch such as `QT_STRICT=True`.

```bash
$ python
>>> from Qt import QtGui
>>> widget = QtGui.QWidget()
>>> exit()
$ export QT_STRICT=True
$ python
>>> from Qt import QtGui
>>> widget = QtGui.QWidget()
AttributeError: 'module' object has no attribute 'QWidget'
```

If so, (1) is the added code worth the trouble? and (2) which value should be the default?

Let me know what you think.