### PR TITLE
Move "distributions" out of "on" part of "deploy"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ deploy:
   user: mottosso
   password:
     secure: kDHKpxgDtn6PoS2Hs0jKd3Xeq+ArFwcOKNW+NkZB2S8+MVxwkzsXBWsvK5Bo14GU/Xoo/PPQKMZi61GNXLJdb/5yGUo9hmuRH/UVCBuFar30pROzHLc2slUL1vbAw82pGa3UCpVLDPi/RVyfUWY4KOnlvr7Hb29IMg/NzfibP4cIEUGFqwp9F1KtE9N8oq6aK5rLznJJwq9Hjj564Zqo4JvEUzucLHnNS4WHFEURuF9gxxQ1E4EZXAnIDGEKmKvBRGKXpDGIJ7hIG9+6fEltZRBdb5jevHxbIjBHKbcK780XnR7gYOQwiCUWaQF90CPbHQA3ff9lKZVDAbQiuYhiqCEVnFCTfgB6D8rL2XQYe/A/pRN8eB2m++ft+v+zYAfmPK+wkNga8wXWMLkc7z+n+aEmeWxopj9MoQqzzKqJeRZ6wgqXWL1YB8TAbUiCRkpcxuMJVu5qIOuWw9eKp+yo6zHjxh6a4MxN50107ZR05ZDEdkU3PgJik5IScWDegJGRQALMCU2Wlis1cdbV8qSosrnMYMdcrpd0R3Bpl/2q9WtUZhZJ7z3GN4YV+d/l0fIUXbrHmOzWjoyW9U8zY2oL+5glCahA6IHBDD+Na47TT93EyMkJ5MxukqNi/rnqUvVdqzgG+tX/HeehNiZkPcN+CWSQoOt1Oeo9pkixpVbjmxA=
+  distributions: "sdist bdist_wheel"
   on:
     tags: true
-    distributions: "sdist bdist_wheel"
     repo: mottosso/Qt.py
     python: 2.7


### PR DESCRIPTION
See the URL below for docs on where travis expects to find "distributions":
https://docs.travis-ci.com/user/deployment/pypi/#Uploading-different-distributions

See issue #162 