### PR TITLE
Exposing select functions through a new c_binding module

### DIFF
--- a/Dockerfile-py2.7
+++ b/Dockerfile-py2.7
@@ -39,6 +39,10 @@ ENTRYPOINT cp -r /Qt.py /workspace && \
     Xvfb :99 -screen 0 1024x768x16 2>/dev/null & \
     while ! ps aux | grep -q '[0]:00 Xvfb :99 -screen 0 1024x768x16'; \
         do echo "Waiting for Xvfb..."; sleep 1; done && \
+    echo "#\n# Testing implementation without c bindings.." && \
+        python -u run_tests.py && \
+    echo "#\n# Installing c bindings.." && \
+    apt-get install -y shiboken shiboken2 && \
     echo "#\n# Testing implementation.." && \
         python -u run_tests.py && \
     echo "#\n# Testing caveats..\n#"  && \

--- a/Dockerfile-py3.5
+++ b/Dockerfile-py3.5
@@ -33,6 +33,10 @@ ENTRYPOINT cp -r /Qt.py /workspace && \
     Xvfb :99 -screen 0 1024x768x16 2>/dev/null & \
     while ! ps aux | grep -q '[0]:00 Xvfb :99 -screen 0 1024x768x16'; \
         do echo "Waiting for Xvfb..."; sleep 1; done && \
+    echo "#\n# Testing implementation without c bindings.." && \
+        python3 -u run_tests.py && \
+    echo "#\n# Installing c bindings.." && \
+    apt-get install -y shiboken shiboken2 && \
     echo "#\n# Testing implementation.." && \
         python3 -u run_tests.py && \
     echo "#\n# Testing caveats..\n#"  && \


### PR DESCRIPTION
A possible approach to addressing #53

- Addition of Qt.c_binding module with functions:
    - wrapInstance
    - getCppPointer (the compliment of wrapInstance)
    - delete
- Graceful handling of the case when the binding is not available.