### PR TITLE
Implement #179

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -63,7 +63,7 @@ import types
 import shutil
 import importlib
 
-__version__ = "1.0.0.b2"
+__version__ = "1.0.0.b3"
 
 # Enable support for `from Qt import *`
 __all__ = []

--- a/Qt.py
+++ b/Qt.py
@@ -660,7 +660,7 @@ def _pyside2():
     Qt.__binding_version__ = module.__version__
 
     if hasattr(Qt, "_QtUiTools"):
-        Qt.QtCompat.load_ui = lambda fname: \
+        Qt.QtCompat.loadUi = lambda fname: \
             Qt._QtUiTools.QUiLoader().load(fname)
 
     if hasattr(Qt, "_QtGui") and hasattr(Qt, "_QtCore"):
@@ -693,7 +693,7 @@ def _pyside():
     Qt.__binding_version__ = module.__version__
 
     if hasattr(Qt, "_QtUiTools"):
-        Qt.QtCompat.load_ui = lambda fname: \
+        Qt.QtCompat.loadUi = lambda fname: \
             Qt._QtUiTools.QUiLoader().load(fname)
 
     if hasattr(Qt, "_QtGui"):
@@ -736,7 +736,7 @@ def _pyqt5():
     _setup(module, ["uic"])
 
     if hasattr(Qt, "_uic"):
-        Qt.QtCompat.load_ui = lambda fname: Qt._uic.loadUi(fname)
+        Qt.QtCompat.loadUi = lambda fname: Qt._uic.loadUi(fname)
 
     if hasattr(Qt, "_QtWidgets"):
         Qt.QtCompat.setSectionResizeMode = \
@@ -782,7 +782,7 @@ def _pyqt4():
     _setup(module, ["uic"])
 
     if hasattr(Qt, "_uic"):
-        Qt.QtCompat.load_ui = lambda fname: Qt._uic.loadUi(fname)
+        Qt.QtCompat.loadUi = lambda fname: Qt._uic.loadUi(fname)
 
     if hasattr(Qt, "_QtGui"):
         setattr(Qt, "QtWidgets", _new_module("QtWidgets"))
@@ -826,7 +826,7 @@ def _none():
     Qt.__binding__ = "None"
     Qt.__qt_version__ = "0.0.0"
     Qt.__binding_version__ = "0.0.0"
-    Qt.QtCompat.load_ui = lambda fname: None
+    Qt.QtCompat.loadUi = lambda fname: None
     Qt.QtCompat.setSectionResizeMode = lambda *args, **kwargs: None
 
     for submodule in _common_members.keys():
@@ -982,6 +982,9 @@ def _install():
                 continue
 
             setattr(our_submodule, member, their_member)
+
+    # Backwards compatibility
+    Qt.QtCompat.load_ui = Qt.QtCompat.loadUi
 
 
 _install()

--- a/tests.py
+++ b/tests.py
@@ -90,7 +90,7 @@ def test_load_ui_returntype():
     import sys
     from Qt import QtWidgets, QtCore, QtCompat
     app = QtWidgets.QApplication(sys.argv)
-    obj = QtCompat.load_ui(self.ui_qwidget)
+    obj = QtCompat.loadUi(self.ui_qwidget)
     assert isinstance(obj, QtCore.QObject)
     app.exit()
 


### PR DESCRIPTION
This makes the naming convention across original and added members uniform.

- #179

```python
from Qt import QtCompat

# Before
QtCompat.load_ui(...)

# After
QtCompat.loadUi(...)
```

The convention is this:

1. mixedCase across the board
2. snake_case for dunder names

As dunder names are unique to Python, they remain [aligned with PEP8](https://www.python.org/dev/peps/pep-0008/#id35), though it's open for discussion whether these should be dunder names at all. E.g. `__binding_version__` could instead be `bindingVersion`.

Thoughts?