### PR TITLE
Implement #185

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -657,7 +657,7 @@ def _pyside2():
     import PySide2 as module
     _setup(module, ["QtUiTools"])
 
-    Qt.__binding_version__ = __import__("PySide2").__version__
+    Qt.__binding_version__ = module.__version__
 
     if hasattr(Qt, "_QtUiTools"):
         Qt.QtCompat.load_ui = lambda fname: \
@@ -690,7 +690,7 @@ def _pyside():
     import PySide as module
     _setup(module, ["QtUiTools"])
 
-    Qt.__binding_version__ = __import__("PySide2").__version__
+    Qt.__binding_version__ = module.__version__
 
     if hasattr(Qt, "_QtUiTools"):
         Qt.QtCompat.load_ui = lambda fname: \

--- a/Qt.py
+++ b/Qt.py
@@ -63,7 +63,7 @@ import types
 import shutil
 import importlib
 
-__version__ = "1.0.0.b1"
+__version__ = "1.0.0.b2"
 
 # Enable support for `from Qt import *`
 __all__ = []

--- a/Qt.py
+++ b/Qt.py
@@ -778,7 +778,7 @@ def _pyqt4():
         # API version already set to v1
         raise ImportError(str(e))
 
-        import PyQt4 as module
+    import PyQt4 as module
     _setup(module, ["uic"])
 
     if hasattr(Qt, "_uic"):

--- a/Qt.py
+++ b/Qt.py
@@ -635,12 +635,13 @@ def _setup(module, extras):
             # print("Failed %s" % name)
             continue
 
+        setattr(Qt, "_" + name, submodule)
+
         if name not in extras:
             # Store reference to original binding,
             # but don't store speciality modules
             # such as uic or QtUiTools
             setattr(Qt, name, _new_module(name))
-            setattr(Qt, "_" + name, submodule)
 
 
 def _pyside2():
@@ -658,18 +659,18 @@ def _pyside2():
 
     Qt.__binding_version__ = __import__("PySide2").__version__
 
-    if hasattr(Qt, "QtUiTools"):
+    if hasattr(Qt, "_QtUiTools"):
         Qt.QtCompat.load_ui = lambda fname: \
             Qt._QtUiTools.QUiLoader().load(fname)
 
-    if hasattr(Qt, "QtGui") and hasattr(Qt, "QtCore"):
+    if hasattr(Qt, "_QtGui") and hasattr(Qt, "_QtCore"):
         Qt.QtCore.QStringListModel = Qt._QtGui.QStringListModel
 
-    if hasattr(Qt, "QtWidgets"):
+    if hasattr(Qt, "_QtWidgets"):
         Qt.QtCompat.setSectionResizeMode = \
             Qt._QtWidgets.QHeaderView.setSectionResizeMode
 
-    if hasattr(Qt, "QtCore"):
+    if hasattr(Qt, "_QtCore"):
         Qt.__qt_version__ = Qt._QtCore.qVersion()
         Qt.QtCompat.translate = Qt._QtCore.QCoreApplication.translate
 
@@ -691,24 +692,24 @@ def _pyside():
 
     Qt.__binding_version__ = __import__("PySide2").__version__
 
-    if hasattr(Qt, "QtUiTools"):
+    if hasattr(Qt, "_QtUiTools"):
         Qt.QtCompat.load_ui = lambda fname: \
             Qt._QtUiTools.QUiLoader().load(fname)
 
-    if hasattr(Qt, "QtGui"):
+    if hasattr(Qt, "_QtGui"):
         setattr(Qt, "QtWidgets", _new_module("QtWidgets"))
         setattr(Qt, "_QtWidgets", Qt._QtGui)
 
         Qt.QtCompat.setSectionResizeMode = Qt._QtGui.QHeaderView.setResizeMode
 
-        if hasattr(Qt, "QtCore"):
+        if hasattr(Qt, "_QtCore"):
             Qt.QtCore.QAbstractProxyModel = Qt._QtGui.QAbstractProxyModel
             Qt.QtCore.QSortFilterProxyModel = Qt._QtGui.QSortFilterProxyModel
             Qt.QtCore.QStringListModel = Qt._QtGui.QStringListModel
             Qt.QtCore.QItemSelection = Qt._QtGui.QItemSelection
             Qt.QtCore.QItemSelectionModel = Qt._QtGui.QItemSelectionModel
 
-    if hasattr(Qt, "QtCore"):
+    if hasattr(Qt, "_QtCore"):
         Qt.__qt_version__ = Qt._QtCore.qVersion()
 
         Qt.QtCore.Property = Qt._QtCore.Property
@@ -734,14 +735,14 @@ def _pyqt5():
     import PyQt5 as module
     _setup(module, ["uic"])
 
-    if hasattr(Qt, "uic"):
+    if hasattr(Qt, "_uic"):
         Qt.QtCompat.load_ui = lambda fname: Qt._uic.loadUi(fname)
 
-    if hasattr(Qt, "QtWidgets"):
+    if hasattr(Qt, "_QtWidgets"):
         Qt.QtCompat.setSectionResizeMode = \
             Qt._QtWidgets.QHeaderView.setSectionResizeMode
 
-    if hasattr(Qt, "QtCore"):
+    if hasattr(Qt, "_QtCore"):
         Qt.QtCompat.translate = Qt._QtCore.QCoreApplication.translate
 
         Qt.QtCore.Property = Qt._QtCore.pyqtProperty
@@ -780,24 +781,24 @@ def _pyqt4():
         import PyQt4 as module
     _setup(module, ["uic"])
 
-    if hasattr(Qt, "uic"):
+    if hasattr(Qt, "_uic"):
         Qt.QtCompat.load_ui = lambda fname: Qt._uic.loadUi(fname)
 
-    if hasattr(Qt, "QtGui"):
+    if hasattr(Qt, "_QtGui"):
         setattr(Qt, "QtWidgets", _new_module("QtWidgets"))
         setattr(Qt, "_QtWidgets", Qt._QtGui)
 
         Qt.QtCompat.setSectionResizeMode = \
             Qt._QtGui.QHeaderView.setResizeMode
 
-        if hasattr(Qt, "QtCore"):
+        if hasattr(Qt, "_QtCore"):
             Qt.QtCore.QAbstractProxyModel = Qt._QtGui.QAbstractProxyModel
             Qt.QtCore.QSortFilterProxyModel = Qt._QtGui.QSortFilterProxyModel
             Qt.QtCore.QItemSelection = Qt._QtGui.QItemSelection
             Qt.QtCore.QStringListModel = Qt._QtGui.QStringListModel
             Qt.QtCore.QItemSelectionModel = Qt._QtGui.QItemSelectionModel
 
-    if hasattr(Qt, "QtCore"):
+    if hasattr(Qt, "_QtCore"):
         Qt.__qt_version__ = Qt._QtCore.QT_VERSION_STR
         Qt.__binding_version__ = Qt._QtCore.PYQT_VERSION_STR
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Qt.py enables you to write software that runs on any of the 4 supported bindings
 | Date     | Version   | Event
 |:---------|:----------|:----------
 | Mar 2017 | [1.0.0][] | Increased safety, **backwards incompatible**
-| Sep 2016 | [0.6.0][] | Introducing `QtCompat`
+| Sep 2016 | [0.6.9][] | Stable release
 | Sep 2016 | [0.5.0][] | Alpha release of `--convert`
 | Jun 2016 | [0.2.6][] | First release of Qt.py
 
@@ -30,6 +30,7 @@ Qt.py enables you to write software that runs on any of the 4 supported bindings
 
 ##### Table of contents
 
+- [Project goals](#project-goals)
 - [Install](#install)
 - [Usage](#usage)
 - [Documentation](#documentation)

--- a/README.md
+++ b/README.md
@@ -26,10 +26,7 @@ Qt.py enables you to write software that runs on any of the 4 supported bindings
 
 - [Developing with Qt.py](https://fredrikaverpil.github.io/2016/07/25/developing-with-qt-py/)
 - [Dealing with Maya 2017 and PySide2](https://fredrikaverpil.github.io/2016/07/25/dealing-with-maya-2017-and-pyside2/)
-
-##### Mentions
-
-- [Qt.py: A portable wrapper for Qt](https://www.udemy.com/python-for-maya/learn/v4/t/lecture/6027394) (Udemy course, registration required)
+- [Udemy Course](https://www.udemy.com/python-for-maya/learn/v4/t/lecture/6027394)
 
 ##### Table of contents
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,34 @@
 
 Qt.py enables you to write software that runs on any of the 4 supported bindings - PySide2, PyQt5, PySide and PyQt4.
 
-**Guides**
+<br>
+
+##### News
+
+| Date     | Version   | Event
+|:---------|:----------|:----------
+| Mar 2017 | [1.0.0][] | Increased safety, **backwards incompatible**
+| Sep 2016 | [0.6.0][] | Introducing `QtCompat`
+| Sep 2016 | [0.5.0][] | Alpha release of `--convert`
+| Jun 2016 | [0.2.6][] | First release of Qt.py
+
+- [More details](https://github.com/mottosso/Qt.py/releases).
+
+[0.2.6]: https://github.com/mottosso/Qt.py/releases/tag/0.2.6
+[0.5.0]: https://github.com/mottosso/Qt.py/releases/tag/0.5.0
+[0.6.0]: https://github.com/mottosso/Qt.py/releases/tag/0.6.0
+[1.0.0]: https://github.com/mottosso/Qt.py/releases/tag/1.0.0
+
+##### Guides
 
 - [Developing with Qt.py](https://fredrikaverpil.github.io/2016/07/25/developing-with-qt-py/)
 - [Dealing with Maya 2017 and PySide2](https://fredrikaverpil.github.io/2016/07/25/dealing-with-maya-2017-and-pyside2/)
 
-**Mentions**
+##### Mentions
+
 - [Qt.py: A portable wrapper for Qt](https://www.udemy.com/python-for-maya/learn/v4/t/lecture/6027394) (Udemy course, registration required)
 
-**Table of contents**
+##### Table of contents
 
 - [Install](#install)
 - [Usage](#usage)

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,1 @@
+docker build -t mottosso/qt.py27 -f Dockerfile-py2.7 .

--- a/build_membership.py
+++ b/build_membership.py
@@ -238,6 +238,7 @@ excluded = {
         "QOpenGLContext",
         "QOpenGLFramebufferObject",
         "QOpenGLShader",
+        "QOpenGLBuffer",
         "QScreen",
     ],
 

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,1 +1,1 @@
-docker run -ti --rm -v /c/Users/marcus/Dropbox/AF/development/marcus/pyblish/Qt:/Qt.py --entrypoint bash mottosso/qt.py27
+docker run -ti --rm -v $(pwd):/Qt.py --entrypoint bash mottosso/qt.py27

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,0 +1,1 @@
+docker run -ti --rm -v /c/Users/marcus/Dropbox/AF/development/marcus/pyblish/Qt:/Qt.py --entrypoint bash mottosso/qt.py27

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -1,0 +1,1 @@
+docker run --rm -v $(pwd):/Qt.py mottosso/qt.py27

--- a/tests.py
+++ b/tests.py
@@ -296,20 +296,19 @@ def test_binding_and_qt_version():
     assert Qt.__qt_version__ != "0.0.0", ("Qt version was not populated")
 
 
-def test_strict():
-    """QT_STRICT exposes only a subset of PySide2"""
-    os.environ["QT_STRICT"] = "1"
-    from Qt import QtGui
-    assert not hasattr(QtGui, "QWidget")
-
-
 def test_cli():
     """Qt.py is available from the command-line"""
-    os.environ.pop("QT_VERBOSE")
-    popen = subprocess.Popen([sys.executable, "Qt.py", "--help"],
-                             stdout=subprocess.PIPE)
+    env = os.environ.copy()
+    env.pop("QT_VERBOSE")  # Do not include debug messages
+
+    popen = subprocess.Popen(
+        [sys.executable, "Qt.py", "--help"],
+        stdout=subprocess.PIPE,
+        env=env
+    )
+
     out, err = popen.communicate()
-    assert out.startswith(b"usage: Qt.py")
+    assert out.startswith(b"usage: Qt.py"), "\n%s" % out
 
 
 if binding("PyQt4"):


### PR DESCRIPTION
This implements #185, a loosening of the strictness in such a way that (1) still only PySide2 members are present, but (2) members are not required.

This should enable use in less than ideal environments, such as certain OSs that lack various submodules or submodule members, such as QtOpenGL, or applications that may or may not expose the entirety of a binding, such as the lack of QtHelp under Houdini.

The result should be software that is robust and reliable, with a Qt.py that is more forgiving where needed.

**To test**

```bash
# Via pip
$ pip install git+https://github.com/abstractfactory/Qt.py.git@implement185
$ python -c "import Qt"

# Via git
$ git clone https://github.com/abstractfactory/Qt.py.git
$ cd Qt
$ git checkout implement185
$ python -c "import Qt"
```

Or copy/paste [this file](https://raw.githubusercontent.com/abstractfactory/Qt.py/implement185/Qt.py).

Let me know what you think!