### PR TITLE
Added QT_PRESERVE_API to prevent changing of API versions

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -783,7 +783,7 @@ def _pyqt4():
         except ValueError as e:
             # API version already set to a different version
             if QT_SIP_API_HINT:
-                _log("Warning: API '%s' has already been set to %s" % (api_name, sip.getapi(api_name)))
+                print("Warning: API '%s' has already been set to %s" % (api_name, sip.getapi(api_name)))
             else:
                 raise ImportError(str(e))
 

--- a/Qt.py
+++ b/Qt.py
@@ -71,7 +71,7 @@ __all__ = []
 # Flags from environment variables
 QT_VERBOSE = bool(os.getenv("QT_VERBOSE"))
 QT_PREFERRED_BINDING = os.getenv("QT_PREFERRED_BINDING", "")
-QT_PRESERVE_API = bool(os.getenv("QT_PRESERVE_API"))
+QT_SIP_API_HINT = int(os.getenv("QT_SIP_API_HINT") or 2) # Set using OR 2 in case env is set but empty string
 
 # Reference to Qt.py
 Qt = sys.modules[__name__]
@@ -762,24 +762,22 @@ def _pyqt5():
 
 def _pyqt4():
     """Initialise PyQt4"""
-    if QT_PRESERVE_API:
-        _log("Preserving the Qt API")
-    else:
-        import sip
-        try:
-            sip.setapi("QString", 2)
-            sip.setapi("QVariant", 2)
-            sip.setapi("QDate", 2)
-            sip.setapi("QDateTime", 2)
-            sip.setapi("QTextStream", 2)
-            sip.setapi("QTime", 2)
-            sip.setapi("QUrl", 2)
-        except AttributeError as e:
-            raise ImportError(str(e))
-            # PyQt4 < v4.6
-        except ValueError as e:
-            # API version already set to v1
-            raise ImportError(str(e))
+    
+    import sip
+    try:
+        sip.setapi("QString", QT_SIP_API_HINT)
+        sip.setapi("QVariant", QT_SIP_API_HINT)
+        sip.setapi("QDate", QT_SIP_API_HINT)
+        sip.setapi("QDateTime", QT_SIP_API_HINT)
+        sip.setapi("QTextStream", QT_SIP_API_HINT)
+        sip.setapi("QTime", QT_SIP_API_HINT)
+        sip.setapi("QUrl", QT_SIP_API_HINT)
+    except AttributeError as e:
+        raise ImportError(str(e))
+        # PyQt4 < v4.6
+    except ValueError as e:
+        # API version already set to a different version
+        raise ImportError(str(e))
 
     import PyQt4 as module
     _setup(module, ["uic"])

--- a/Qt.py
+++ b/Qt.py
@@ -71,6 +71,7 @@ __all__ = []
 # Flags from environment variables
 QT_VERBOSE = bool(os.getenv("QT_VERBOSE"))
 QT_PREFERRED_BINDING = os.getenv("QT_PREFERRED_BINDING", "")
+QT_PRESERVE_API = bool(os.getenv("QT_PRESERVE_API"))
 
 # Reference to Qt.py
 Qt = sys.modules[__name__]
@@ -761,22 +762,24 @@ def _pyqt5():
 
 def _pyqt4():
     """Initialise PyQt4"""
-
-    import sip
-    try:
-        sip.setapi("QString", 2)
-        sip.setapi("QVariant", 2)
-        sip.setapi("QDate", 2)
-        sip.setapi("QDateTime", 2)
-        sip.setapi("QTextStream", 2)
-        sip.setapi("QTime", 2)
-        sip.setapi("QUrl", 2)
-    except AttributeError as e:
-        raise ImportError(str(e))
-        # PyQt4 < v4.6
-    except ValueError as e:
-        # API version already set to v1
-        raise ImportError(str(e))
+    if QT_PRESERVE_API:
+        _log("Preserving the Qt API")
+    else:
+        import sip
+        try:
+            sip.setapi("QString", 2)
+            sip.setapi("QVariant", 2)
+            sip.setapi("QDate", 2)
+            sip.setapi("QDateTime", 2)
+            sip.setapi("QTextStream", 2)
+            sip.setapi("QTime", 2)
+            sip.setapi("QUrl", 2)
+        except AttributeError as e:
+            raise ImportError(str(e))
+            # PyQt4 < v4.6
+        except ValueError as e:
+            # API version already set to v1
+            raise ImportError(str(e))
 
     import PyQt4 as module
     _setup(module, ["uic"])

--- a/Qt.py
+++ b/Qt.py
@@ -790,7 +790,7 @@ def _pyqt4():
             actual = sip.getapi(api)
             if hint:
                 sys.stderr.write(
-                    "Warning: API '%s' has already been set to %d"
+                    "Warning: API '%s' has already been set to %d.\n"
                     % (api, actual)
                 )
             else:

--- a/Qt.py
+++ b/Qt.py
@@ -765,13 +765,12 @@ def _pyqt4():
 
     import sip
 
-    # Validation of envivornment variable.
-    # Prevents an error if the variable is
-    # invalid since it's just a hint.
+    # Validation of envivornment variable. Prevents an error if
+    # the variable is invalid since it's just a hint.
     try:
         hint = int(QT_SIP_API_HINT)
     except TypeError:
-        hint = None
+        hint = None  # Variable was None, i.e. not set.
     except ValueError:
         raise ImportError("QT_SIP_API_HINT=%s must be a 1 or 2")
 
@@ -788,13 +787,15 @@ def _pyqt4():
             raise ImportError("PyQt4 < 4.6 isn't supported by Qt.py")
         except ValueError:
             actual = sip.getapi(api)
-            if hint:
+            if not hint:
+                raise ImportError("API version already set to %d" % actual)
+            else:
+                # Having provided a hint indicates a soft constraint, one
+                # that doesn't throw an exception.
                 sys.stderr.write(
                     "Warning: API '%s' has already been set to %d.\n"
                     % (api, actual)
                 )
-            else:
-                raise ImportError("API version already set to %d" % actual)
 
     import PyQt4 as module
     _setup(module, ["uic"])

--- a/README.md
+++ b/README.md
@@ -379,6 +379,21 @@ if binding("PyQt4"):
         pass
 ```
 
+**Code convention**
+
+Below are some of the conventions that used throughout the Qt.py module and tests.
+
+- **Etiquette: PEP8**
+ 	- All code is written in PEP8. It is recommended you use a linter as you work, flake8 and pylinter are both good options. Anaconda if using Sublime is another good option.
+- **Etiquette: Double quotes**
+    - " = yes, ' = no.
+- **Etiquette: Napoleon docstrings**
+	- Any docstrings are made in Google Napoleon format. See [Napoleon](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for details.
+- **Etiquette: Semantic Versioning**
+	- This project follows [semantic versioning](http://semver.org).
+- **Etiquette: Underscore means private**
+	- Anything prefixed with an underscore means that it is internal to Qt.py and not for public consumption.
+
 **Running tests**
 
 Due to the nature of multiple bindings and multiple interpreter support, setting up a development environment in which to properly test your contraptions can be challenging. So here is a guide for how to do just that using **Docker**.

--- a/tests.py
+++ b/tests.py
@@ -328,14 +328,14 @@ if binding("PyQt4"):
             "PyQt4 API version should be 2, "
             "instead is %s" % sip.getapi("QString"))
 
+    if PYTHON == 2:
+        def test_sip_api_already_set():
+            """Raise ImportError if sip API v1 was already set and no hint is provided"""
 
-    def test_sip_api_already_set():
-        """Raise ImportError if sip API v1 was already set and no hint is provided"""
-
-        __import__("PyQt4.QtCore")  # Bypass linter warning
-        import sip
-        sip.setapi("QString", 1)
-        assert_raises(ImportError, __import__, "Qt")
+            __import__("PyQt4.QtCore")  # Bypass linter warning
+            import sip
+            sip.setapi("QString", 1)
+            assert_raises(ImportError, __import__, "Qt")
 
     def test_sip_api_with_matching_hint():
         """Should not raise error if import hint matches current"""

--- a/tests.py
+++ b/tests.py
@@ -328,15 +328,27 @@ if binding("PyQt4"):
             "PyQt4 API version should be 2, "
             "instead is %s" % sip.getapi("QString"))
 
-    if PYTHON == 2:
-        def test_sip_api_already_set():
-            """Raise ImportError if sip API v1 was already set"""
 
-            __import__("PyQt4.QtCore")  # Bypass linter warning
-            import sip
-            sip.setapi("QString", 1)
-            assert_raises(ImportError, __import__, "Qt")
+    def test_sip_api_already_set():
+        """Raise ImportError if sip API v1 was already set and no hint is provided"""
 
+        __import__("PyQt4.QtCore")  # Bypass linter warning
+        import sip
+        sip.setapi("QString", 1)
+        assert_raises(ImportError, __import__, "Qt")
+
+    def test_sip_api_with_matching_hint():
+        """Should not raise error if import hint matches current"""
+        import sip
+        sip.setapi('QString', 1)
+        import Qt
+
+    def test_sip_api_with_non_matching_hint():
+        """Should not error if the sip API hint is set but they don't match"""
+        import sip
+        sip.setapi('QString', 2)
+        os.environ['QT_SIP_API_HINT'] = '1'
+        import Qt
 
 if binding("PyQt5"):
     def test_preferred_pyqt5():

--- a/tests.py
+++ b/tests.py
@@ -341,6 +341,7 @@ if binding("PyQt4"):
         """Should not raise error if import hint matches current"""
         import sip
         sip.setapi('QString', 1)
+        os.environ['QT_SIP_API_HINT'] = '1'
         import Qt
 
     def test_sip_api_with_non_matching_hint():


### PR DESCRIPTION
During the porting of legacy code to Qt.py the changing of API versions
causes issues. By optionally preserving it, we can control that behavior.

This is primarily an issue when porting legacy code to use Qt where we are in an environment where importing Qt in bootstraps could cause issues when it changed the api.

https://github.com/mottosso/Qt.py/issues/188