### PR TITLE
Implement wrapInstance and getCppPointer (#59)

### DIFF
--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -9,6 +9,7 @@ There are cases where Qt.py is not handling incompatibility issues.
 - [QtGui.QRegExpValidator](#qtguiqregexpvalidator)
 - [QtWidgets.QHeaderView.setResizeMode](#qtwidgetsqheaderviewsetresizemode)
 - [QtWidgets.qApp](#qtwidgetsqapp)
+- [QtCompat.wrapInstance](#qtcompatwrapinstance)
 
 <br>
 <br>
@@ -307,3 +308,38 @@ Technically, there is no difference between the two, apart from more characters 
 >>> app == QtWidgets.QApplication.instance()
 True
 ```
+
+
+#### QtCompat.wrapInstance
+
+`QtCompat.wrapInstance` differs across `sip` and `shiboken` in subtle ways.
+
+```python
+# PySide2
+>>> from Qt import QtCompat, QtWidgets
+>>> app = QtWidgets.QApplication(sys.argv)
+>>> button = QtWidgets.QPushButton("Hello world")
+>>> button.setObjectName("MySpecialButton")
+>>> pointer = QtCompat.getCppPointer(button)
+>>> widget = QtCompat.wrapInstance(long(pointer))
+>>> assert isinstance(widget, QtWidgets.QWidget), widget
+>>> assert widget.objectName() == button.objectName()
+>>> widget == button
+False
+```
+
+```python
+# PyQt5
+>>> from Qt import QtCompat, QtWidgets
+>>> app = QtWidgets.QApplication(sys.argv)
+>>> button = QtWidgets.QPushButton("Hello world")
+>>> button.setObjectName("MySpecialButton")
+>>> pointer = QtCompat.getCppPointer(button)
+>>> widget = QtCompat.wrapInstance(long(pointer))
+>>> assert isinstance(widget, QtWidgets.QWidget), widget
+>>> assert widget.objectName() == button.objectName()
+>>> widget == button
+True
+```
+
+Note the `False` for PySide2 and `True` for PyQt5.

--- a/Dockerfile-py2.7
+++ b/Dockerfile-py2.7
@@ -8,6 +8,7 @@ RUN apt-get update && \
         software-properties-common && \
     add-apt-repository -y ppa:thopiekar/pyside-git && \
     apt-get update && apt-get install -y \
+        nano \
         python \
         python-dev \
         python-pip \
@@ -16,7 +17,20 @@ RUN apt-get update && \
         python-pyside \
         python-pyside2 \
         pyside2-tools \
+        libshiboken2-dev \
         xvfb
+
+# Build shiboken
+RUN apt-get install -y \
+        wget \
+        libqt4-dev \
+        cmake && \
+    wget https://pypi.python.org/packages/source/S/Shiboken/Shiboken-1.2.2.tar.gz && \
+    tar -xvzf Shiboken-1.2.2.tar.gz && \
+    cd Shiboken-1.2.2 && \
+    python setup.py bdist_wheel --qmake=/usr/bin/qmake-qt4 && \
+    pip install dist/Shiboken-1.2.2-cp27-cp27mu-linux_x86_64.whl && \
+    python shiboken_postinstall.py -install
 
 # Make pyside2uic availble for Python 2.x
 RUN cp -avr /usr/lib/python3/dist-packages/pyside2uic /usr/local/lib/python2.7/dist-packages
@@ -32,6 +46,7 @@ ENV QT_TESTING true
 ENV DISPLAY :99
 
 # Warnings are exceptions
+ENV PYTHONPATH=/Shiboken-1.2.2/shiboken_package/Shiboken
 ENV PYTHONWARNINGS="ignore"
 
 WORKDIR /workspace/Qt.py

--- a/Dockerfile-py2.7
+++ b/Dockerfile-py2.7
@@ -36,7 +36,10 @@ RUN apt-get install -y \
 RUN cp -avr /usr/lib/python3/dist-packages/pyside2uic /usr/local/lib/python2.7/dist-packages
 
 # Nose is the Python test-runner
-RUN pip install nose nosepipe
+RUN pip install \
+    nose \
+    nosepipe \
+    six
 
 # Enable additional output from Qt.py
 ENV QT_VERBOSE true

--- a/Dockerfile-py3.5
+++ b/Dockerfile-py3.5
@@ -24,7 +24,10 @@ RUN apt-get update && \
         xvfb
 
 # Nose is the Python test-runner
-RUN pip3 install nose nosepipe
+RUN pip3 install \
+    nose \
+    nosepipe \
+    six
 
 # Enable additional output from Qt.py
 ENV QT_VERBOSE true

--- a/Dockerfile-py3.5
+++ b/Dockerfile-py3.5
@@ -3,11 +3,15 @@ FROM ubuntu:16.04
 # Needed to install pyside2-tools without issues
 ENV DEBIAN_FRONTEND noninteractive
 
+# Expose shiboken to apt-get
+RUN echo deb http://us.archive.ubuntu.com/ubuntu xenial main universe >> /etc/apt/sources.list
+
 RUN apt-get update && \
     apt-get install -y \
         software-properties-common && \
     add-apt-repository -y ppa:thopiekar/pyside-git && \
     apt-get update && apt-get install -y \
+        nano \
         python3 \
         python3-dev \
         python3-pip \
@@ -16,6 +20,7 @@ RUN apt-get update && \
         python3-pyside \
         python3-pyside2 \
         pyside2-tools \
+        libshiboken2-dev \
         xvfb
 
 # Nose is the Python test-runner

--- a/Qt.py
+++ b/Qt.py
@@ -660,6 +660,15 @@ def _pyside2():
 
     Qt.__binding_version__ = module.__version__
 
+    try:
+        import shiboken2
+        Qt.QtCompat.wrapInstance = shiboken2.wrapInstance
+        Qt.QtCompat.getCppPointer = lambda object: \
+            shiboken2.getCppPointer(object)[0]
+
+    except ImportError:
+        pass  # Optional
+
     if hasattr(Qt, "_QtUiTools"):
         Qt.QtCompat.loadUi = lambda fname: \
             Qt._QtUiTools.QUiLoader().load(fname)
@@ -693,6 +702,15 @@ def _pyside():
     _setup(module, ["QtUiTools"])
 
     Qt.__binding_version__ = module.__version__
+
+    try:
+        import shiboken
+        Qt.QtCompat.wrapInstance = shiboken.wrapInstance
+        Qt.QtCompat.getCppPointer = lambda object: \
+            shiboken.getCppPointer(object)[0]
+
+    except ImportError:
+        pass  # Optional
 
     if hasattr(Qt, "_QtUiTools"):
         Qt.QtCompat.loadUi = lambda fname: \
@@ -737,6 +755,15 @@ def _pyqt5():
 
     import PyQt5 as module
     _setup(module, ["uic"])
+
+    try:
+        import sip
+        Qt.QtCompat.wrapInstance = sip.wrapinstance
+        Qt.QtCompat.getCppPointer = lambda object: \
+            sip.unwrapinstance(object)
+
+    except ImportError:
+        pass  # Optional
 
     if hasattr(Qt, "_uic"):
         Qt.QtCompat.loadUi = lambda fname: Qt._uic.loadUi(fname)
@@ -802,6 +829,15 @@ def _pyqt4():
 
     import PyQt4 as module
     _setup(module, ["uic"])
+
+    try:
+        import sip
+        Qt.QtCompat.wrapInstance = sip.wrapinstance
+        Qt.QtCompat.getCppPointer = lambda object: \
+            sip.unwrapinstance(object)
+
+    except ImportError:
+        pass  # Optional
 
     if hasattr(Qt, "_uic"):
         Qt.QtCompat.loadUi = lambda fname: Qt._uic.loadUi(fname)

--- a/Qt.py
+++ b/Qt.py
@@ -77,6 +77,12 @@ QT_SIP_API_HINT = os.getenv("QT_SIP_API_HINT")
 Qt = sys.modules[__name__]
 Qt.QtCompat = types.ModuleType("QtCompat")
 
+try:
+    long
+except NameError:
+    # Python 3 compatibility
+    long = int
+
 """Common members of all bindings
 
 This is where each member of Qt.py is explicitly defined.
@@ -629,11 +635,9 @@ def _setup(module, extras):
 
     for name in list(_common_members) + extras:
         try:
-            # print("Trying %s" % name)
             submodule = importlib.import_module(
                 module.__name__ + "." + name)
         except ImportError:
-            # print("Failed %s" % name)
             continue
 
         setattr(Qt, "_" + name, submodule)

--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ Qt.py also provides compatibility wrappers for critical functionality that diffe
 
 | Attribute               | Returns     | Description
 |:------------------------|:------------|:------------
-| `load_ui(fname=str)`    | `QObject`   | Minimal wrapper of PyQt4.loadUi and PySide equivalent
+| `loadUi(fname=str)`     | `QObject`   | Minimal wrapper of PyQt4.loadUi and PySide equivalent
 | `translate(...)`        | `function`  | Compatibility wrapper around [QCoreApplication.translate][]
 | `setSectionResizeMode()`| `method`    | Compatibility wrapper around [QAbstractItemView.setSectionResizeMode][]
+| `wrapInstance(addr=long, type=QObject)` | `QObject` | Wrapper around `shiboken2.wrapInstance` and PyQt equivalent
+| `getCppPointer(object=QObject)`    | `long`      | Wrapper around `shiboken2.getCppPointer` and PyQt equivalent
 
 [QCoreApplication.translate]: https://doc.qt.io/qt-5/qcoreapplication.html#translate
 [QAbstractItemView.setSectionResizeMode]: https://doc.qt.io/qt-5/qheaderview.html#setSectionResizeMode

--- a/caveats.py
+++ b/caveats.py
@@ -117,6 +117,12 @@ def test_{count}_{header}():
     '''Test {header}
 
     >>> import os, sys
+    >>> try:
+    ...   long
+    ... except NameError:
+    ...   # For Python 3
+    ...   long = int
+    ...
     >>> _ = os.environ.pop("QT_VERBOSE", None)  # Disable debug output
     >>> os.environ["QT_PREFERRED_BINDING"] = "{binding}"
     {body}

--- a/caveats.py
+++ b/caveats.py
@@ -117,12 +117,8 @@ def test_{count}_{header}():
     '''Test {header}
 
     >>> import os, sys
-    >>> try:
-    ...   long
-    ... except NameError:
-    ...   # For Python 3
-    ...   long = int
-    ...
+    >>> PYTHON = sys.version_info[0]
+    >>> long = int if PYTHON == 3 else long
     >>> _ = os.environ.pop("QT_VERBOSE", None)  # Disable debug output
     >>> os.environ["QT_PREFERRED_BINDING"] = "{binding}"
     {body}

--- a/tests.py
+++ b/tests.py
@@ -328,6 +328,21 @@ def test_cli():
     assert out.startswith(b"usage: Qt.py"), "\n%s" % out
 
 
+if PYTHON == 2:
+    def test_wrapInstance():
+        """.wrapInstance and .getCppPointer is identical across all bindings"""
+        from Qt import QtCompat, QtWidgets
+
+        app = QtWidgets.QApplication(sys.argv)
+
+        try:
+            button = QtWidgets.QPushButton("Hello world")
+            pointer = QtCompat.getCppPointer(button)
+            widget = QtCompat.wrapInstance(long(pointer), QtWidgets.QWidget)
+            assert isinstance(widget, QtWidgets.QWidget), widget
+        finally:
+            app.exit()
+
 if binding("PyQt4"):
     def test_preferred_pyqt4():
         """QT_PREFERRED_BINDING = PyQt4 properly forces the binding"""

--- a/tests.py
+++ b/tests.py
@@ -337,9 +337,41 @@ if PYTHON == 2:
 
         try:
             button = QtWidgets.QPushButton("Hello world")
+            button.setObjectName("MySpecialButton")
             pointer = QtCompat.getCppPointer(button)
-            widget = QtCompat.wrapInstance(long(pointer), QtWidgets.QWidget)
+            widget = QtCompat.wrapInstance(long(pointer),
+                                           QtWidgets.QWidget)
             assert isinstance(widget, QtWidgets.QWidget), widget
+            assert widget.objectName() == button.objectName()
+
+            # IMPORTANT: this differs across sip and shiboken.
+            if binding("PySide") or binding("PySide2"):
+                assert widget != button
+            else:
+                assert widget == button
+
+        finally:
+            app.exit()
+
+    def test_implicit_wrapInstance():
+        """.wrapInstance doesn't need the `base` argument"""
+        from Qt import QtCompat, QtWidgets
+
+        app = QtWidgets.QApplication(sys.argv)
+
+        try:
+            button = QtWidgets.QPushButton("Hello world")
+            button.setObjectName("MySpecialButton")
+            pointer = QtCompat.getCppPointer(button)
+            widget = QtCompat.wrapInstance(long(pointer))
+            assert isinstance(widget, QtWidgets.QWidget), widget
+            assert widget.objectName() == button.objectName()
+
+            if binding("PySide") or binding("PySide2"):
+                assert widget != button
+            else:
+                assert widget == button
+
         finally:
             app.exit()
 


### PR DESCRIPTION
This adds a wrapper for `wrapInstance` and `getCppPointer` from `shiboken2` and automatically unifies the differences with `shiboken` and `sip` for both Python 2 and 3.

| Attribute               | Returns    
|:------------------------|:-----------
| `QtCompat.wrapInstance(addr=long, type=QObject)` | `QObject` |
 `QtCompat.getCppPointer(object=QObject)`    | `long`    

- See #53 for details.
- To **test**, copy/paste [this file](https://raw.githubusercontent.com/abstractfactory/Qt.py/implement59/Qt.py)

**Usage**

```python
import sys
from Qt import QtCompat, QtWidgets
app = QtWidgets.QApplication(sys.argv)
button = QtWidgets.QPushButton("Hello world")
pointer = QtCompat.getCppPointer(button)
widget = QtCompat.wrapInstance(long(pointer), QtWidgets.QWidget)
assert widget == button
app.exit()
```

**Maya Example**

This works for both 2016 and 2017.

```python
import sys
from maya import OpenMayaUI
from Qt import QtCompat, QtWidgets
pointer = OpenMayaUI.MQtUtil.mainWindow()
widget = QtCompat.wrapInstance(long(pointer), QtWidgets.QWidget)
assert isinstance(widget, QtWidgets.QWidget)
```

### Important

This addition requires `sip`, `shiboken` or `shiboken2` to be available on your system. If not found, Qt.py will still import successfully, but these members will not be available.

In such cases, here is a Qt-only version and guaranteed cross-compatible version of the above.

```python
from Qt import QtWidgets
app = QtWidgets.QApplication.instance()
widget = {o.objectName(): o for o in app.topLevelWidgets()}["MayaWindow"]
```

The same pattern may be applied to any and all uses of `sip`, `shiboken` and `shiboken2`, as discussed in-depth at #53.

Enjoy!