### PR TITLE
pyside needs QItemSlectionRange

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -707,6 +707,7 @@ def _pyside():
             Qt.QtCore.QSortFilterProxyModel = Qt._QtGui.QSortFilterProxyModel
             Qt.QtCore.QStringListModel = Qt._QtGui.QStringListModel
             Qt.QtCore.QItemSelection = Qt._QtGui.QItemSelection
+            Qt.QtCore.QItemSelectionRange = Qt._QtGui.QItemSelectionRange
             Qt.QtCore.QItemSelectionModel = Qt._QtGui.QItemSelectionModel
 
     if hasattr(Qt, "_QtCore"):


### PR DESCRIPTION
Thank you for develop and maintain Qt.py.

My script raises exception on Maya2015 (PySide).

`
from Qt import QtCore
QtCore.QItemSelectionRange(index)
`

# AttributeError: 'module' object has no attribute 'QItemSelectionRange'

But does not raise exception on Maya2017.

I can't check other Qt binding libraries. sorry.
I hope this PR will be helpful.
