### PR TITLE
PySide2 also needs QItemSelectionRange.

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -681,6 +681,7 @@ def _pyside2():
         Qt.QtCore.QAbstractProxyModel = Qt._QtCore.QAbstractProxyModel
         Qt.QtCore.QSortFilterProxyModel = Qt._QtCore.QSortFilterProxyModel
         Qt.QtCore.QItemSelection = Qt._QtCore.QItemSelection
+        Qt.QtCore.QItemSelectionRange = Qt._QtCore.QItemSelectionRange
         Qt.QtCore.QItemSelectionModel = Qt._QtCore.QItemSelectionModel
 
 

--- a/Qt.py
+++ b/Qt.py
@@ -756,6 +756,7 @@ def _pyqt5():
         Qt.QtCore.QStringListModel = Qt._QtCore.QStringListModel
         Qt.QtCore.QItemSelection = Qt._QtCore.QItemSelection
         Qt.QtCore.QItemSelectionModel = Qt._QtCore.QItemSelectionModel
+        Qt.QtCore.QItemSelectionRange = Qt._QtCore.QItemSelectionRange
 
         Qt.__qt_version__ = Qt._QtCore.QT_VERSION_STR
         Qt.__binding_version__ = Qt._QtCore.PYQT_VERSION_STR
@@ -799,6 +800,7 @@ def _pyqt4():
             Qt.QtCore.QItemSelection = Qt._QtGui.QItemSelection
             Qt.QtCore.QStringListModel = Qt._QtGui.QStringListModel
             Qt.QtCore.QItemSelectionModel = Qt._QtGui.QItemSelectionModel
+            Qt.QtCore.QItemSelectionRange = Qt._QtGui.QItemSelectionRange
 
     if hasattr(Qt, "_QtCore"):
         Qt.__qt_version__ = Qt._QtCore.QT_VERSION_STR


### PR DESCRIPTION
Thank you for maintaining.

Not found QtCore.QItemSelectionRange on Maya 2017(PySide2) on Windows.
I Add QitemSelectionRange to PySide2 block.

Similar to this PR.
https://github.com/mottosso/Qt.py/pull/191
