### PR TITLE
_convert: fix conversion of compiled .ui to Qt.py when QtCompat.translate is called

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -950,9 +950,9 @@ def _convert(lines):
     """
 
     def parse(line):
-        line = line.replace("from PySide2 import", "from Qt import")
+        line = line.replace("from PySide2 import", "from Qt import QtCompat,")
         line = line.replace("QtWidgets.QApplication.translate",
-                            "Qt.QtCompat.translate")
+                            "QtCompat.translate")
         return line
 
     parsed = list()

--- a/tests.py
+++ b/tests.py
@@ -284,7 +284,7 @@ class Ui_uic(object):
 """.split("\n")
 
     after = """\
-from Qt import QtCore, QtGui, QtWidgets
+from Qt import QtCompat, QtCore, QtGui, QtWidgets
 
 class Ui_uic(object):
     def setupUi(self, uic):
@@ -292,7 +292,7 @@ class Ui_uic(object):
 
     def retranslateUi(self, uic):
         self.pushButton_2.setText(
-            Qt.QtCompat.translate("uic", "NOT Ok", None, -1))
+            QtCompat.translate("uic", "NOT Ok", None, -1))
 """.split("\n")
 
     from Qt import QtCompat
@@ -314,7 +314,7 @@ class Ui_uic(object):
 """
 
     after = """\
-from Qt import QtCore, QtGui, QtWidgets
+from Qt import QtCompat, QtCore, QtGui, QtWidgets
 
 class Ui_uic(object):
     def setupUi(self, uic):
@@ -322,7 +322,7 @@ class Ui_uic(object):
 
     def retranslateUi(self, uic):
         self.pushButton_2.setText(
-            Qt.QtCompat.translate("uic", "NOT Ok", None, -1))
+            QtCompat.translate("uic", "NOT Ok", None, -1))
 """
 
     fname = os.path.join(self.tempdir, "idempotency.py")


### PR DESCRIPTION
Hi there,

A small code contribution to handle an issue we faced when converting a compiled .ui file from PySide2 to Qt.py when _QtWidgets.QApplication.translate_ is called.

Considering this code:
```python
from PySide2 import QtCore, QtGui, QtWidgets
dialog.setWindowTitle(QtWidgets.QApplication.translate("MyDialog", "MY DIALOG", None, -1))
```


Before this fix, it becomes:
```python
from Qt import QtCore, QtGui, QtWidgets
dialog.setWindowTitle(Qt.QtCompat.translate("MyDialog", "MY DIALOG", None, -1))
```

After this fix, it becomes:
```python
from Qt import QtCompat, QtCore, QtGui, QtWidgets
dialog.setWindowTitle(QtCompat.translate("MyDialog", "MY DIALOG", None, -1))
```