### PR TITLE
PyCharm autocomplete support

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -45,6 +45,15 @@ import importlib
 
 __version__ = "1.0.0.b4"
 
+def path():
+    print("Foo")
+
+# For Autocomplete support inside of packages like PyCharm.
+# Tricks PyCharm into believing these namespaces are imported
+if False:
+    from PySide2 import QtWidgets, QtGui, QtCore
+    from PyQt5 import QtWidgets, QtGui, QtCore
+
 # Enable support for `from Qt import *`
 __all__ = []
 

--- a/Qt.py
+++ b/Qt.py
@@ -45,8 +45,6 @@ import importlib
 
 __version__ = "1.0.0.b4"
 
-def path():
-    print("Foo")
 
 # For Autocomplete support inside of packages like PyCharm.
 # Tricks PyCharm into believing these namespaces are imported

--- a/Qt.py
+++ b/Qt.py
@@ -45,7 +45,6 @@ import importlib
 
 __version__ = "1.0.0.b4"
 
-
 # For Autocomplete support inside of packages like PyCharm.
 # Tricks PyCharm into believing these namespaces are imported
 if False:


### PR DESCRIPTION
This lets PyCharm autocomplete based on either the systems available PyQt5 or PySide2 bindings.
If you try and do the same with any Qt4 bindings it doesn't seem to like it, maybe because there are so many overlapping ones, but it seems fine with just these two

![Image of Autocomplete](https://cdn.pbrd.co/images/adVe3U7DH.gif)

