### PR TITLE
Binding State Enums

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -1088,10 +1088,10 @@ def _install():
 _install()
 
 # Setup Binding Enum states
-Qt.PYSIDE2 = Qt.__binding__ == 'PySide2'
-Qt.PYQT5 = Qt.__binding__ == 'PyQt5'
-Qt.PYSIDE = Qt.__binding__ == 'PySide'
-Qt.PYQT4 = Qt.__binding__ == 'PyQt4'
+Qt.isPySide2 = lambda: Qt.__binding__ == 'PySide2'
+Qt.isPyQt5 = lambda: Qt.__binding__ == 'PyQt5'
+Qt.isPySide = lambda: Qt.__binding__ == 'PySide'
+Qt.isPyQt4 = lambda: Qt.__binding__ == 'PyQt4'
 
 """Augment QtCompat
 

--- a/Qt.py
+++ b/Qt.py
@@ -1088,7 +1088,7 @@ def _install():
 _install()
 
 # Setup Binding Enum states
-Qt.PYSIDE2 = Qt.__binding__  == 'PySide2'
+Qt.PYSIDE2 = Qt.__binding__ == 'PySide2'
 Qt.PYQT5 = Qt.__binding__ == 'PyQt5'
 Qt.PYSIDE = Qt.__binding__ == 'PySide'
 Qt.PYQT4 = Qt.__binding__ == 'PyQt4'

--- a/Qt.py
+++ b/Qt.py
@@ -1087,6 +1087,11 @@ def _install():
 
 _install()
 
+# Setup Binding Enum states
+Qt.PYSIDE2 = Qt.__binding__  == 'PySide2'
+Qt.PYQT5 = Qt.__binding__ == 'PyQt5'
+Qt.PYSIDE = Qt.__binding__ == 'PySide'
+Qt.PYQT4 = Qt.__binding__ == 'PyQt4'
 
 """Augment QtCompat
 

--- a/Qt.py
+++ b/Qt.py
@@ -1088,10 +1088,10 @@ def _install():
 _install()
 
 # Setup Binding Enum states
-Qt.isPySide2 = lambda: Qt.__binding__ == 'PySide2'
-Qt.isPyQt5 = lambda: Qt.__binding__ == 'PyQt5'
-Qt.isPySide = lambda: Qt.__binding__ == 'PySide'
-Qt.isPyQt4 = lambda: Qt.__binding__ == 'PyQt4'
+Qt.IsPySide2 = Qt.__binding__ == 'PySide2'
+Qt.IsPyQt5 = Qt.__binding__ == 'PyQt5'
+Qt.IsPySide = Qt.__binding__ == 'PySide'
+Qt.IsPyQt4 = Qt.__binding__ == 'PyQt4'
 
 """Augment QtCompat
 

--- a/tests.py
+++ b/tests.py
@@ -410,10 +410,10 @@ def test_binding_and_qt_version():
 def test_binding_states():
     """Tests to see if the Qt binding enum states are set properly"""
     import Qt
-    assert Qt.isPySide() == binding("PySide")
-    assert Qt.isPySide2() == binding("PySide2")
-    assert Qt.isPyQt5() == binding("PyQt5")
-    assert Qt.isPyQt4() == binding("PyQt4")
+    assert Qt.IsPySide == binding("PySide")
+    assert Qt.IsPySide2 == binding("PySide2")
+    assert Qt.IsPyQt5 == binding("PyQt5")
+    assert Qt.IsPyQt4 == binding("PyQt4")
 
 
 def test_cli():

--- a/tests.py
+++ b/tests.py
@@ -410,10 +410,10 @@ def test_binding_and_qt_version():
 def test_binding_states():
     """Tests to see if the Qt binding enum states are set properly"""
     import Qt
-    assert Qt.PYSIDE == binding("PySide")
-    assert Qt.PYSIDE2 == binding("PySide2")
-    assert Qt.PYQT5 == binding("PyQt5")
-    assert Qt.PYQT4 == binding("PyQt4")
+    assert Qt.isPySide() == binding("PySide")
+    assert Qt.isPySide2() == binding("PySide2")
+    assert Qt.isPyQt5() == binding("PyQt5")
+    assert Qt.isPyQt4() == binding("PyQt4")
 
 
 def test_cli():

--- a/tests.py
+++ b/tests.py
@@ -397,14 +397,13 @@ def test_translate_arguments():
     assert result == u'Status', result
 
 
-def test_binding_and_qt_version():
-    """Qt's __binding_version__ and __qt_version__ populated"""
-
+def test_binding_states():
+    """Tests to see if the Qt binding enum states are set properly"""
     import Qt
-
-    assert Qt.__binding_version__ != "0.0.0", ("Binding version was not "
-                                               "populated")
-    assert Qt.__qt_version__ != "0.0.0", ("Qt version was not populated")
+    assert Qt.PYSIDE == binding("PySide")
+    assert Qt.PYSIDE2 == binding("PySide2")
+    assert Qt.PYQT5 == binding("PyQt5")
+    assert Qt.PYQT4 == binding("PyQt4")
 
 
 def test_cli():
@@ -537,3 +536,13 @@ if binding("PySide") or binding("PySide2"):
         assert Qt.__binding__ == "PySide", (
             "PySide should have been picked, "
             "instead got %s" % Qt.__binding__)
+
+
+def test_binding_and_qt_version():
+    """Qt's __binding_version__ and __qt_version__ populated"""
+
+    import Qt
+
+    assert Qt.__binding_version__ != "0.0.0", ("Binding version was not "
+                                               "populated")
+    assert Qt.__qt_version__ != "0.0.0", ("Qt version was not populated")

--- a/tests.py
+++ b/tests.py
@@ -546,4 +546,3 @@ if binding("PySide") or binding("PySide2"):
         assert Qt.__binding__ == "PySide", (
             "PySide should have been picked, "
             "instead got %s" % Qt.__binding__)
-

--- a/tests.py
+++ b/tests.py
@@ -397,6 +397,16 @@ def test_translate_arguments():
     assert result == u'Status', result
 
 
+def test_binding_and_qt_version():
+    """Qt's __binding_version__ and __qt_version__ populated"""
+
+    import Qt
+
+    assert Qt.__binding_version__ != "0.0.0", ("Binding version was not "
+                                               "populated")
+    assert Qt.__qt_version__ != "0.0.0", ("Qt version was not populated")
+
+
 def test_binding_states():
     """Tests to see if the Qt binding enum states are set properly"""
     import Qt
@@ -537,12 +547,3 @@ if binding("PySide") or binding("PySide2"):
             "PySide should have been picked, "
             "instead got %s" % Qt.__binding__)
 
-
-def test_binding_and_qt_version():
-    """Qt's __binding_version__ and __qt_version__ populated"""
-
-    import Qt
-
-    assert Qt.__binding_version__ != "0.0.0", ("Binding version was not "
-                                               "populated")
-    assert Qt.__qt_version__ != "0.0.0", ("Qt version was not populated")


### PR DESCRIPTION
This adds flags to `Qt.py` that allow end users to check the binding more easily.
Rather  than comparing strings in every piece of code like so:

```python
if Qt.__binding__ == 'PySide2': doSomething()
```

They can now simply do

```python
if Qt.PYSIDE2: doSomething()
```

This in turn makes for less error prone code since string comparisons have the increased risks of typos not caught till runtime.
