### PR TITLE
Fix #208

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -897,7 +897,7 @@ def _loadUi(uifile, baseinstance=None):
                     self, uifile, *args, **kwargs)
 
                 # Prevent RuntimeError in Nuke 9.0v9 with PySide 1.0.9
-                parent = widget.parentWidget()
+                widget.parentWidget()
 
                 return widget
 

--- a/Qt.py
+++ b/Qt.py
@@ -897,7 +897,7 @@ def _loadUi(uifile, baseinstance=None):
                     self, uifile, *args, **kwargs)
 
                 # Prevent RuntimeError in Nuke 9.0v9 with PySide 1.0.9
-                widget.parentWidget()
+                parent = widget.parentWidget()
 
                 return widget
 

--- a/Qt.py
+++ b/Qt.py
@@ -893,8 +893,13 @@ def _loadUi(uifile, baseinstance=None):
                 etree = ElementTree()
                 etree.parse(uifile)
 
-                return Qt._QtUiTools.QUiLoader.load(
+                widget = Qt._QtUiTools.QUiLoader.load(
                     self, uifile, *args, **kwargs)
+
+                # Prevent RuntimeError in Nuke 9.0v9 with PySide 1.0.9
+                parent = widget.parentWidget()
+
+                return widget
 
             def createWidget(self, class_name, parent=None, name=""):
                 """Called for each widget defined in ui file

--- a/Qt.py
+++ b/Qt.py
@@ -896,7 +896,7 @@ def _loadUi(uifile, baseinstance=None):
                 widget = Qt._QtUiTools.QUiLoader.load(
                     self, uifile, *args, **kwargs)
 
-                # Workaround for PySide 1.0.9, see issue #209
+                # Workaround for PySide 1.0.9, see issue #208
                 widget.parentWidget()
 
                 return widget

--- a/Qt.py
+++ b/Qt.py
@@ -897,7 +897,7 @@ def _loadUi(uifile, baseinstance=None):
                     self, uifile, *args, **kwargs)
 
                 # Prevent RuntimeError in Nuke 9.0v9 with PySide 1.0.9
-                parent = widget.parentWidget()
+                Qt.QtCompat._loadUi_temp = widget.parentWidget()
 
                 return widget
 
@@ -935,6 +935,7 @@ def _loadUi(uifile, baseinstance=None):
 
         widget = _UiLoader(baseinstance).load(uifile)
         Qt.QtCore.QMetaObject.connectSlotsByName(widget)
+        del Qt.QtCompat._loadUi_temp
 
         return widget
 

--- a/Qt.py
+++ b/Qt.py
@@ -896,8 +896,8 @@ def _loadUi(uifile, baseinstance=None):
                 widget = Qt._QtUiTools.QUiLoader.load(
                     self, uifile, *args, **kwargs)
 
-                # Prevent RuntimeError in Nuke 9.0v9 with PySide 1.0.9
-                Qt.QtCompat._loadUi_temp = widget.parentWidget()
+                # Workaround for PySide 1.0.9, see issue #209
+                widget.parentWidget()
 
                 return widget
 
@@ -935,7 +935,6 @@ def _loadUi(uifile, baseinstance=None):
 
         widget = _UiLoader(baseinstance).load(uifile)
         Qt.QtCore.QMetaObject.connectSlotsByName(widget)
-        del Qt.QtCompat._loadUi_temp
 
         return widget
 


### PR DESCRIPTION
This fixes #208.

I tested this with Nuke 9.0v9 (where the issue is hit), Nuke 10.0v6, Nuke10.5v4 and Nuke 11 beta. I also tested this with Maya/PySide2.

After having read about [this (fixed) PySide bug](https://bugreports.qt.io/browse/PYSIDE-10), it seems you can avoid the garbage collection by calling [`widget.parentWidget()`](http://doc.qt.io/qt-5/qwidget.html#parentWidget). 🤔 