### PR TITLE
QtCompat namespacing

### DIFF
--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -264,7 +264,7 @@ Use compatibility wrapper.
 >>> app = QtWidgets.QApplication(sys.argv)
 >>> view = QtWidgets.QTreeWidget()
 >>> header = view.header()
->>> QtCompat.setSectionResizeMode(header, QtWidgets.QHeaderView.Fixed)
+>>> QtCompat.QHeaderView.setSectionResizeMode(header, QtWidgets.QHeaderView.Fixed)
 ```
 
 Or a conditional.
@@ -281,6 +281,10 @@ Or a conditional.
 ...   header.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
 ```
 
+Note: Qt.QtCompat.setSectionResizeMode is a older way this was handled and has been left in for now, but this will likely be removed in the future.
+
+<br>
+<br>
 
 #### QtWidgets.qApp
 

--- a/Qt.py
+++ b/Qt.py
@@ -671,7 +671,8 @@ _compatibility_members = {
     "pyside2": {
         "QHeaderView": {
             "sectionsClickable": "_QtWidgets.QHeaderView.sectionsClickable",
-            "setSectionsClickable": "_QtWidgets.QHeaderView.setSectionsClickable",
+            "setSectionsClickable":
+                "_QtWidgets.QHeaderView.setSectionsClickable",
             "sectionResizeMode": "_QtWidgets.QHeaderView.sectionResizeMode",
             "setSectionResizeMode":
                 "_QtWidgets.QHeaderView.setSectionResizeMode",
@@ -687,7 +688,8 @@ _compatibility_members = {
     "pyqt5": {
         "QHeaderView": {
             "sectionsClickable": "_QtWidgets.QHeaderView.sectionsClickable",
-            "setSectionsClickable": "_QtWidgets.QHeaderView.setSectionsClickable",
+            "setSectionsClickable":
+                "_QtWidgets.QHeaderView.setSectionsClickable",
             "sectionResizeMode": "_QtWidgets.QHeaderView.sectionResizeMode",
             "setSectionResizeMode":
                 "_QtWidgets.QHeaderView.setSectionResizeMode",

--- a/Qt.py
+++ b/Qt.py
@@ -670,56 +670,64 @@ interface for obsolete members, and differences in binding return values.
 _compatibility_members = {
     "pyside2": {
         "QHeaderView": {
-            'sectionResizeMode': '_QtWidgets.QHeaderView.sectionResizeMode',
-            'setSectionResizeMode':
-                '_QtWidgets.QHeaderView.setSectionResizeMode',
-            'sectionsMovable': '_QtWidgets.QHeaderView.sectionsMovable',
-            'setSectionsMovable': '_QtWidgets.QHeaderView.setSectionsMovable',
+            "sectionsClickable": "_QtWidgets.QHeaderView.sectionsClickable",
+            "setSectionsClickable": "_QtWidgets.QHeaderView.setSectionsClickable",
+            "sectionResizeMode": "_QtWidgets.QHeaderView.sectionResizeMode",
+            "setSectionResizeMode":
+                "_QtWidgets.QHeaderView.setSectionResizeMode",
+            "sectionsMovable": "_QtWidgets.QHeaderView.sectionsMovable",
+            "setSectionsMovable": "_QtWidgets.QHeaderView.setSectionsMovable",
         },
         "QFileDialog": {
-            'getOpenFileName': '_QtWidgets.QFileDialog.getOpenFileName',
-            'getOpenFileNames': '_QtWidgets.QFileDialog.getOpenFileNames',
-            'getSaveFileName': '_QtWidgets.QFileDialog.getSaveFileName',
+            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
         },
     },
     "pyqt5": {
         "QHeaderView": {
-            'sectionResizeMode': '_QtWidgets.QHeaderView.sectionResizeMode',
-            'setSectionResizeMode':
-                '_QtWidgets.QHeaderView.setSectionResizeMode',
-            'sectionsMovable': '_QtWidgets.QHeaderView.sectionsMovable',
-            'setSectionsMovable': '_QtWidgets.QHeaderView.setSectionsMovable',
+            "sectionsClickable": "_QtWidgets.QHeaderView.sectionsClickable",
+            "setSectionsClickable": "_QtWidgets.QHeaderView.setSectionsClickable",
+            "sectionResizeMode": "_QtWidgets.QHeaderView.sectionResizeMode",
+            "setSectionResizeMode":
+                "_QtWidgets.QHeaderView.setSectionResizeMode",
+            "sectionsMovable": "_QtWidgets.QHeaderView.sectionsMovable",
+            "setSectionsMovable": "_QtWidgets.QHeaderView.setSectionsMovable",
         },
         "QFileDialog": {
-            'getOpenFileName': '_QtWidgets.QFileDialog.getOpenFileName',
-            'getOpenFileNames': '_QtWidgets.QFileDialog.getOpenFileNames',
-            'getSaveFileName': '_QtWidgets.QFileDialog.getSaveFileName',
+            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
         },
     },
     "pyside": {
         "QHeaderView": {
-            'sectionResizeMode': '_QtWidgets.QHeaderView.resizeMode',
-            'setSectionResizeMode': '_QtWidgets.QHeaderView.setResizeMode',
-            'sectionsMovable': '_QtWidgets.QHeaderView.isMovable',
-            'setSectionsMovable': '_QtWidgets.QHeaderView.setMovable',
+            "sectionsClickable": "_QtWidgets.QHeaderView.isClickable",
+            "setSectionsClickable": "_QtWidgets.QHeaderView.setClickable",
+            "sectionResizeMode": "_QtWidgets.QHeaderView.resizeMode",
+            "setSectionResizeMode": "_QtWidgets.QHeaderView.setResizeMode",
+            "sectionsMovable": "_QtWidgets.QHeaderView.isMovable",
+            "setSectionsMovable": "_QtWidgets.QHeaderView.setMovable",
         },
         "QFileDialog": {
-            'getOpenFileName': '_QtWidgets.QFileDialog.getOpenFileName',
-            'getOpenFileNames': '_QtWidgets.QFileDialog.getOpenFileNames',
-            'getSaveFileName': '_QtWidgets.QFileDialog.getSaveFileName',
+            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
         },
     },
     "pyqt4": {
         "QHeaderView": {
-            'sectionResizeMode': '_QtWidgets.QHeaderView.resizeMode',
-            'setSectionResizeMode': '_QtWidgets.QHeaderView.setResizeMode',
-            'sectionsMovable': '_QtWidgets.QHeaderView.isMovable',
-            'setSectionsMovable': '_QtWidgets.QHeaderView.setMovable',
+            "sectionsClickable": "_QtWidgets.QHeaderView.isClickable",
+            "setSectionsClickable": "_QtWidgets.QHeaderView.setClickable",
+            "sectionResizeMode": "_QtWidgets.QHeaderView.resizeMode",
+            "setSectionResizeMode": "_QtWidgets.QHeaderView.setResizeMode",
+            "sectionsMovable": "_QtWidgets.QHeaderView.isMovable",
+            "setSectionsMovable": "_QtWidgets.QHeaderView.setMovable",
         },
         "QFileDialog": {
-            'getOpenFileName': '_QtWidgets.QFileDialog.getOpenFileName',
-            'getOpenFileNames': '_QtWidgets.QFileDialog.getOpenFileNames',
-            'getSaveFileName': '_QtWidgets.QFileDialog.getSaveFileName',
+            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
         },
     },
 }

--- a/Qt.py
+++ b/Qt.py
@@ -1399,7 +1399,8 @@ def _install():
             setattr(our_submodule, member, their_member)
 
     # Backwards compatibility
-    Qt.QtCompat.load_ui = Qt.QtCompat.loadUi
+    if hasattr(Qt.QtCompat, 'loadUi'):
+        Qt.QtCompat.load_ui = Qt.QtCompat.loadUi
 
 
 _install()

--- a/Qt.py
+++ b/Qt.py
@@ -1134,7 +1134,7 @@ def _pyqt4():
         "getOpenFileName:_QtWidgets.QFileDialog.getOpenFileName":
             _standardizeQFileDialog,
         "getOpenFileNames:_QtWidgets.QFileDialog.getOpenFileNames":
-                _standardizeQFileDialog,
+            _standardizeQFileDialog,
         "getSaveFileName:_QtWidgets.QFileDialog.getSaveFileName":
             _standardizeQFileDialog,
     }

--- a/Qt.py
+++ b/Qt.py
@@ -671,7 +671,7 @@ _compatibility_members = {
     "pyside2": {
         "QHeaderView": {
             'sectionResizeMode': '_QtWidgets.QHeaderView.sectionResizeMode',
-            'setSectionResizeMode': \
+            'setSectionResizeMode':
                 '_QtWidgets.QHeaderView.setSectionResizeMode',
             'sectionsMovable': '_QtWidgets.QHeaderView.sectionsMovable',
             'setSectionsMovable': '_QtWidgets.QHeaderView.setSectionsMovable',
@@ -685,7 +685,7 @@ _compatibility_members = {
     "pyqt5": {
         "QHeaderView": {
             'sectionResizeMode': '_QtWidgets.QHeaderView.sectionResizeMode',
-            'setSectionResizeMode': \
+            'setSectionResizeMode':
                 '_QtWidgets.QHeaderView.setSectionResizeMode',
             'sectionsMovable': '_QtWidgets.QHeaderView.sectionsMovable',
             'setSectionsMovable': '_QtWidgets.QHeaderView.setSectionsMovable',

--- a/Qt.py
+++ b/Qt.py
@@ -883,8 +883,8 @@ def _build_compatibility_members(binding, decorators={}):
             attrs[target] = src_object
 
         # Create the QtCompat class and install it into the namespace
-        cls = type(classname, tuple([_QtCompat]), attrs)
-        setattr(Qt.QtCompat, classname, cls)
+        compat_class = type(classname, tuple([_QtCompat]), attrs)
+        setattr(Qt.QtCompat, classname, compat_class)
 
 
 def _pyside2():

--- a/Qt.py
+++ b/Qt.py
@@ -43,7 +43,7 @@ import types
 import shutil
 import importlib
 
-__version__ = "1.1.0.b1"
+__version__ = "1.1.0.b3"
 
 # Enable support for `from Qt import *`
 __all__ = []

--- a/Qt.py
+++ b/Qt.py
@@ -611,7 +611,7 @@ These members from the original submodule are misplaced relative PySide2
 
 """
 _misplaced_members = {
-    "pyside2": {
+    "PySide2": {
         "QtGui.QStringListModel": "QtCore.QStringListModel",
         "QtCore.Property": "QtCore.Property",
         "QtCore.Signal": "QtCore.Signal",
@@ -621,7 +621,7 @@ _misplaced_members = {
         "QtCore.QItemSelection": "QtCore.QItemSelection",
         "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
     },
-    "pyqt5": {
+    "PyQt5": {
         "QtCore.pyqtProperty": "QtCore.Property",
         "QtCore.pyqtSignal": "QtCore.Signal",
         "QtCore.pyqtSlot": "QtCore.Slot",
@@ -631,7 +631,7 @@ _misplaced_members = {
         "QtCore.QItemSelection": "QtCore.QItemSelection",
         "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
     },
-    "pyside": {
+    "PySide": {
         "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
         "QtGui.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
         "QtGui.QStringListModel": "QtCore.QStringListModel",
@@ -642,7 +642,7 @@ _misplaced_members = {
         "QtCore.Slot": "QtCore.Slot",
 
     },
-    "pyqt4": {
+    "PyQt4": {
         "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
         "QtGui.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
         "QtGui.QItemSelection": "QtCore.QItemSelection",
@@ -668,7 +668,7 @@ interface for obsolete members, and differences in binding return values.
 }
 """
 _compatibility_members = {
-    "pyside2": {
+    "PySide2": {
         "QHeaderView": {
             "sectionsClickable": "_QtWidgets.QHeaderView.sectionsClickable",
             "setSectionsClickable":
@@ -685,7 +685,7 @@ _compatibility_members = {
             "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
         },
     },
-    "pyqt5": {
+    "PyQt5": {
         "QHeaderView": {
             "sectionsClickable": "_QtWidgets.QHeaderView.sectionsClickable",
             "setSectionsClickable":
@@ -702,7 +702,7 @@ _compatibility_members = {
             "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
         },
     },
-    "pyside": {
+    "PySide": {
         "QHeaderView": {
             "sectionsClickable": "_QtWidgets.QHeaderView.isClickable",
             "setSectionsClickable": "_QtWidgets.QHeaderView.setClickable",
@@ -717,7 +717,7 @@ _compatibility_members = {
             "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
         },
     },
-    "pyqt4": {
+    "PyQt4": {
         "QHeaderView": {
             "sectionsClickable": "_QtWidgets.QHeaderView.isClickable",
             "setSectionsClickable": "_QtWidgets.QHeaderView.setClickable",
@@ -925,8 +925,8 @@ def _pyside2():
         Qt.QtCompat.setSectionResizeMode = \
             Qt._QtWidgets.QHeaderView.setSectionResizeMode
 
-    _reassign_misplaced_members("pyside2")
-    _build_compatibility_members("pyside2")
+    _reassign_misplaced_members("PySide2")
+    _build_compatibility_members("PySide2")
 
 
 def _pyside():
@@ -972,8 +972,8 @@ def _pyside():
             )
         )
 
-    _reassign_misplaced_members("pyside")
-    _build_compatibility_members("pyside")
+    _reassign_misplaced_members("PySide")
+    _build_compatibility_members("PySide")
 
 
 def _pyqt5():
@@ -1006,8 +1006,8 @@ def _pyqt5():
         Qt.QtCompat.setSectionResizeMode = \
             Qt._QtWidgets.QHeaderView.setSectionResizeMode
 
-    _reassign_misplaced_members("pyqt5")
-    _build_compatibility_members('pyqt5')
+    _reassign_misplaced_members("PyQt5")
+    _build_compatibility_members('PyQt5')
 
 
 def _pyqt4():
@@ -1087,7 +1087,7 @@ def _pyqt4():
                 n)
         )
 
-    _reassign_misplaced_members("pyqt4")
+    _reassign_misplaced_members("PyQt4")
 
     # QFileDialog QtCompat decorator
     def _standardizeQFileDialog(some_function):
@@ -1108,7 +1108,7 @@ def _pyqt4():
         "_QtWidgets.QFileDialog.getOpenFileNames": _standardizeQFileDialog,
         "_QtWidgets.QFileDialog.getSaveFileName": _standardizeQFileDialog,
     }
-    _build_compatibility_members('pyqt4', decorators)
+    _build_compatibility_members('PyQt4', decorators)
 
 
 def _none():

--- a/README.md
+++ b/README.md
@@ -232,15 +232,16 @@ If you need to expose a module that isn't included in Qt.py by default or wish t
 
 ```python
 # QtSiteConfig.py
-def update_members(members):
-	"""Called by Qt.py at run-time to modify the modules it makes available.
+def update_members(members, step):
+    """Called by Qt.py at run-time to modify the modules it makes available.
 
     Arguments:
         members (dict): The members considered by Qt.py
-
+        step (str): Used to identify what members will be used for.
     """
 
-    members.pop("QtCore")
+    if step == 'common':
+        members.pop("QtCore")
 ```
 
 Finally, expose the module to Python.
@@ -386,6 +387,7 @@ Send us a pull-request with your studio here.
 - [CGRU](http://cgru.info/)
 - [MPC](http://www.moving-picture.com)
 - [Rising Sun Pictures](https://rsp.com.au)
+- [Blur Studio](http://www.blur.com)
 
 Presented at Siggraph 2016, BOF!
 

--- a/README.md
+++ b/README.md
@@ -128,25 +128,38 @@ All members of `Qt` stem directly from those available via PySide2, along with t
 'PyQt5'
 ```
 
+### Compatibility
+
 Qt.py also provides compatibility wrappers for critical functionality that differs across bindings, these can be found in the added `QtCompat` submodule.
 
 | Attribute                                 | Returns     | Description
 |:------------------------------------------|:------------|:------------
 | `loadUi(uifile=str, baseinstance=QWidget)`| `QObject`   | Minimal wrapper of PyQt4.loadUi and PySide equivalent
 | `translate(...)`        					| `function`  | Compatibility wrapper around [QCoreApplication.translate][]
-| `setSectionResizeMode()`					| `method`    | Compatibility wrapper around [QAbstractItemView.setSectionResizeMode][]
 | `wrapInstance(addr=long, type=QObject)`   | `QObject`   | Wrapper around `shiboken2.wrapInstance` and PyQt equivalent
 | `getCppPointer(object=QObject)`           | `long`      | Wrapper around `shiboken2.getCppPointer` and PyQt equivalent
 
 [QCoreApplication.translate]: https://doc.qt.io/qt-5/qcoreapplication.html#translate
-[QAbstractItemView.setSectionResizeMode]: https://doc.qt.io/qt-5/qheaderview.html#setSectionResizeMode
 
 **Example**
 
 ```python
 >>> from Qt import QtCompat
->>> QtCompat.setSectionResizeMode
+>>> QtCompat.loadUi
 ```
+
+#### Class specific compatibility objects
+
+Between Qt4 and Qt5 there have been many classes and class members that are obsolete. Under Qt.QtCompat there are many classes with names matching the classes they provide compatibility functions. These will match the PySide2 naming convention.
+
+```python
+from Qt import QtCore, QtWidgets, QtCompat
+header = QtWidgets.QHeaderView(QtCore.Qt.Horizontal)
+QtCompat.QHeaderView.setSectionsMovable(header, False)
+movable = QtCompat.QHeaderView.sectionsMovable(header)
+```
+
+This also covers inconsistencies between bindings. For example PyQt4's QFileDialog matches Qt4's return value of the selected. While all other bindings return the selected filename and the file filter the user used to select the file. `Qt.QtCompat.QFileDialog` ensures that getOpenFileName(s) and getSaveFileName always return the tuple.
 
 <br>
 

--- a/examples/QtSiteConfig/QtSiteConfig.py
+++ b/examples/QtSiteConfig/QtSiteConfig.py
@@ -1,6 +1,7 @@
 # Contrived example used for unit testing. For a more realistic example
 # see the README
 
+
 def update_members(members, step):
     """This function is called by Qt.py to modify the modules it exposes.
 
@@ -26,6 +27,7 @@ def update_members(members, step):
                 # the returned value.
                 "windowTitleDecorator": "_QtWidgets.QWidget.windowTitle",
             }
+
 
 def update_compatibility_decorators(binding, decorators):
     """ This function is called by Qt.py to modify the decorators applied to

--- a/examples/QtSiteConfig/QtSiteConfig.py
+++ b/examples/QtSiteConfig/QtSiteConfig.py
@@ -1,14 +1,54 @@
-# Contrived example used for unit testing. This makes the QtCore module
-# not accessible. I chose this so it can be tested everywhere, for a more
-# realistic example see the README
+# Contrived example used for unit testing. For a more realistic example
+# see the README
 
-
-def update_members(members):
+def update_members(members, step):
     """This function is called by Qt.py to modify the modules it exposes.
 
     Arguments:
         members (dict): The members considered by Qt.py
-
+        step (str): Used to identify what members will be used for.
     """
 
-    members.pop("QtCore")
+    if step == 'common':
+        # Contrived example used for unit testing. This makes the QtCore module
+        # not accessible. I chose this so it can be tested everywhere, for a
+        # more realistic example see the README
+        members.pop("QtCore")
+
+    elif step == 'compatibility':
+        # Create a QtCompat.QWidget compatibility class. This example is
+        # is used to provide a testable unittest
+        for binding in ("PySide2", "PyQt5", "PySide", "PyQt4"):
+            members[binding]["QWidget"] = {
+                # Simple remapping of QWidget.windowTitle
+                "windowTitleTest": "_QtWidgets.QWidget.windowTitle",
+                # Remap QWidget.windowTitle with a decorator that modifies
+                # the returned value.
+                "windowTitleDecorator": "_QtWidgets.QWidget.windowTitle",
+            }
+
+def update_compatibility_decorators(binding, decorators):
+    """ This function is called by Qt.py to modify the decorators applied to
+    QtCompat namespace objects. Defining this method is optional.
+
+    Arguments:
+        binding (str): The Qt binding being wrapped by Qt.py
+        decorators (dict): Maps specific decorator functions to
+            QtCompat namespace functions. See Qt._build_compatibility_members
+            for more info.
+    """
+
+    def _testFunction(some_function):
+        def wrapper(*args, **kwargs):
+            ret = some_function(*args, **kwargs)
+            # Modifies the returned value so we can test that the
+            # decorator works.
+            return 'Test: {}'.format(ret)
+        # preserve docstring and name of original function
+        wrapper.__doc__ = some_function.__doc__
+        wrapper.__name__ = some_function.__name__
+        return wrapper
+
+    # Install the decorator so it will be applied to the QtCompat object
+    decorators['windowTitleDecorator:_QtWidgets.QWidget.windowTitle'] = \
+        _testFunction

--- a/examples/QtSiteConfig/README.md
+++ b/examples/QtSiteConfig/README.md
@@ -28,9 +28,13 @@ $ python main.py
 
 If you need to  you can also add modules that are not in the standard Qt.py.
 
+#### QtSiteConfig.py: Adding non-standard modules
+
+This example shows how to add a module that is not included by default with Qt.py.
+
 ```python
 def update_members_example(members):
-    """An example of adding QJsonDocument to QtCore and the Qsci.
+    """An example of adding Qsci to Qt.py.
     
     Remove "_example" from the function name to use this example.
 
@@ -40,61 +44,115 @@ def update_members_example(members):
 
     """
 
-    # Include QJsonDocument module
-    members["QtCore"].append("QJsonDocument")
+    if step == 'common':
+        # Include Qsci module for scintilla lexer support.
+        members["Qsci"] = [
+            "QsciAPIs",
+            "QsciAbstractAPIs",
+            "QsciCommand",
+            "QsciCommandSet",
+            "QsciDocument",
+            "QsciLexer",
+            "QsciLexerAVS",
+            "QsciLexerBash",
+            "QsciLexerBatch",
+            "QsciLexerCMake",
+            "QsciLexerCPP",
+            "QsciLexerCSS",
+            "QsciLexerCSharp",
+            "QsciLexerCoffeeScript",
+            "QsciLexerCustom",
+            "QsciLexerD",
+            "QsciLexerDiff",
+            "QsciLexerFortran",
+            "QsciLexerFortran77",
+            "QsciLexerHTML",
+            "QsciLexerIDL",
+            "QsciLexerJSON",
+            "QsciLexerJava",
+            "QsciLexerJavaScript",
+            "QsciLexerLua",
+            "QsciLexerMakefile",
+            "QsciLexerMarkdown",
+            "QsciLexerMatlab",
+            "QsciLexerOctave",
+            "QsciLexerPO",
+            "QsciLexerPOV",
+            "QsciLexerPascal",
+            "QsciLexerPerl",
+            "QsciLexerPostScript",
+            "QsciLexerProperties",
+            "QsciLexerPython",
+            "QsciLexerRuby",
+            "QsciLexerSQL",
+            "QsciLexerSpice",
+            "QsciLexerTCL",
+            "QsciLexerTeX",
+            "QsciLexerVHDL",
+            "QsciLexerVerilog",
+            "QsciLexerXML",
+            "QsciLexerYAML",
+            "QsciMacro",
+            "QsciPrinter",
+            "QsciScintilla",
+            "QsciScintillaBase",
+            "QsciStyle",
+            "QsciStyledText",
+        ]
+```
 
-    # Include Qsci module for scintilla lexer support.
-    members["Qsci"] = [
-        "QsciAPIs",
-        "QsciAbstractAPIs",
-        "QsciCommand",
-        "QsciCommandSet",
-        "QsciDocument",
-        "QsciLexer",
-        "QsciLexerAVS",
-        "QsciLexerBash",
-        "QsciLexerBatch",
-        "QsciLexerCMake",
-        "QsciLexerCPP",
-        "QsciLexerCSS",
-        "QsciLexerCSharp",
-        "QsciLexerCoffeeScript",
-        "QsciLexerCustom",
-        "QsciLexerD",
-        "QsciLexerDiff",
-        "QsciLexerFortran",
-        "QsciLexerFortran77",
-        "QsciLexerHTML",
-        "QsciLexerIDL",
-        "QsciLexerJSON",
-        "QsciLexerJava",
-        "QsciLexerJavaScript",
-        "QsciLexerLua",
-        "QsciLexerMakefile",
-        "QsciLexerMarkdown",
-        "QsciLexerMatlab",
-        "QsciLexerOctave",
-        "QsciLexerPO",
-        "QsciLexerPOV",
-        "QsciLexerPascal",
-        "QsciLexerPerl",
-        "QsciLexerPostScript",
-        "QsciLexerProperties",
-        "QsciLexerPython",
-        "QsciLexerRuby",
-        "QsciLexerSQL",
-        "QsciLexerSpice",
-        "QsciLexerTCL",
-        "QsciLexerTeX",
-        "QsciLexerVHDL",
-        "QsciLexerVerilog",
-        "QsciLexerXML",
-        "QsciLexerYAML",
-        "QsciMacro",
-        "QsciPrinter",
-        "QsciScintilla",
-        "QsciScintillaBase",
-        "QsciStyle",
-        "QsciStyledText",
-    ]
+
+#### QtSiteConfig.py: Standardizing PyQt4 functionality
+
+This example reproduces functionality already in Qt.py but it provides a good example of what is necessary to create your QtCompat namespaces with custom function decorators to change how the source function runs.
+
+```python
+def update_members_example(members, step):
+    """This function is called by Qt.py to modify the modules it exposes.
+
+    Remove "_example" from the function name to use this example.
+
+    Arguments:
+        members (dict): The members considered by Qt.py
+        step (str): Used to identify what members will be used for.
+    """
+    if step == 'compatibility':
+        members['PyQt4']["QFileDialog"] = {
+            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
+        }
+
+def update_compatibility_decorators_example(binding, decorators):
+    """ This function is called by Qt.py to modify the decorators applied to
+    QtCompat namespace objects. Defining this method is optional.
+
+    Remove "_example" from the function name to use this example.
+
+    Arguments:
+        binding (str): The Qt binding being wrapped by Qt.py
+        decorators (dict): Maps specific decorator functions to
+            QtCompat namespace functions. See Qt._build_compatibility_members
+            for more info.
+    """
+    if binding == 'PyQt4':
+        # QFileDialog QtCompat decorator
+        def _standardizeQFileDialog(some_function):
+            """ decorator that makes PyQt4 return conform to other bindings
+            """
+            def wrapper(*args, **kwargs):
+                ret = some_function(*args, **kwargs)
+                # PyQt4 only returns the selected filename
+                # force the return to conform to all other bindings
+                return (ret, '')
+            # preserve docstring and name of original function
+            wrapper.__doc__ = some_function.__doc__
+            wrapper.__name__ = some_function.__name__
+            return wrapper
+        decorators["getOpenFileName:_QtWidgets.QFileDialog.getOpenFileName"] = \
+            _standardizeQFileDialog
+        decorators["getOpenFileNames:_QtWidgets.QFileDialog.getOpenFileNames"] = \
+            _standardizeQFileDialog
+        decorators["getSaveFileName:_QtWidgets.QFileDialog.getSaveFileName"] = \
+            _standardizeQFileDialog
 ```

--- a/examples/QtSiteConfig/main.py
+++ b/examples/QtSiteConfig/main.py
@@ -33,10 +33,15 @@ def test():
     win.setWindowTitle(title)
 
     # Verify that our simple remapping of QWidget.windowTitle works
-    assert QtCompat.QWidget.windowTitleTest(win) == title
+    assert QtCompat.QWidget.windowTitleTest(win) == title, \
+        "Non-decorated function was added to QtCompat.QWidget"
     # Verify that our decorated remapping of QWidget.windowTitle works
     check = 'Test: {}'.format(title)
-    assert QtCompat.QWidget.windowTitleDecorator(win) == check
+    assert QtCompat.QWidget.windowTitleDecorator(win) == check, \
+        "Decorated function was added to QtCompat.QWidget"
+
+    # Suppress 'app' imported but unused warning
+    app
 
 
 if __name__ == '__main__':

--- a/examples/QtSiteConfig/main.py
+++ b/examples/QtSiteConfig/main.py
@@ -25,6 +25,19 @@ def test():
         # Suppress 'Qt.QtCore' imported but unused warning
         QtCore
 
+    # Test _compatibility_members is applied correctly
+    title = 'Test Widget'
+    from Qt import QtWidgets, QtCompat
+    app = QtWidgets.QApplication(sys.argv)
+    win = QtWidgets.QWidget()
+    win.setWindowTitle(title)
+
+    # Verify that our simple remapping of QWidget.windowTitle works
+    assert QtCompat.QWidget.windowTitleTest(win) == title
+    # Verify that our decorated remapping of QWidget.windowTitle works
+    check = 'Test: {}'.format(title)
+    assert QtCompat.QWidget.windowTitleDecorator(win) == check
+
 
 if __name__ == '__main__':
     test()

--- a/tests.py
+++ b/tests.py
@@ -420,6 +420,23 @@ def test_binding_states():
     assert Qt.IsPyQt4 == binding("PyQt4")
 
 
+def test_qtcompat_base_class():
+    """Tests to ensure the QtCompat namespace object works as expected"""
+    import sys
+    import Qt
+    from Qt.QtWidgets import QHeaderView, QApplication
+    from Qt import QtCompat
+    app = QApplication(sys.argv)
+    # suppress `local variable 'app' is assigned to but never used`
+    app
+    header = QHeaderView(Qt.QtCore.Qt.Horizontal)
+
+    # Spot check compatibility functions
+    QtCompat.QHeaderView.setSectionsMovable(header, False)
+    assert QtCompat.QHeaderView.sectionsMovable(header) is False
+    QtCompat.QHeaderView.setSectionsMovable(header, True)
+    assert QtCompat.QHeaderView.sectionsMovable(header) is True
+
 def test_cli():
     """Qt.py is available from the command-line"""
     env = os.environ.copy()

--- a/tests.py
+++ b/tests.py
@@ -424,12 +424,12 @@ def test_qtcompat_base_class():
     """Tests to ensure the QtCompat namespace object works as expected"""
     import sys
     import Qt
-    from Qt.QtWidgets import QHeaderView, QApplication
+    from Qt import QtWidgets
     from Qt import QtCompat
-    app = QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     # suppress `local variable 'app' is assigned to but never used`
     app
-    header = QHeaderView(Qt.QtCore.Qt.Horizontal)
+    header = QtWidgets.QHeaderView(Qt.QtCore.Qt.Horizontal)
 
     # Spot check compatibility functions
     QtCompat.QHeaderView.setSectionsMovable(header, False)


### PR DESCRIPTION
#151 

I've added a framework for adding a class namespace for QtCompat functions. This allows gives you a clear indication of what type of QObject you should be calling this function on.

## Naming
These objects should have a unique name so they don't conflict with real Qt objects, but the name should make it easy to identify what type QObject they are intended to work on. Currently I'm adding a t after the Q so `QFileDialog` becomes `QtFileDialog`, and `QHeaderView` becomes `QtHeaderView`. Some other ideas I have are 'QFileDialogCompat', 'QFileDialogC', 'CFileDialog', 'CompatQFileDialog', but I'm open to any suggestions.

## Implementation
I am using type to create the classes dynamically. For example this is how I'm creating the PySide implementation of the QtHeaderView class. It has 4 methods.
```python
attrs = dict(
    sectionResizeMode = Qt._QtWidgets.QHeaderView.resizeMode,
    setSectionResizeMode = Qt._QtWidgets.QHeaderView.setResizeMode,
    sectionsMovable = Qt._QtWidgets.QHeaderView.isMovable,
    setSectionsMovable = Qt._QtWidgets.QHeaderView.setMovable
)
# type(name, bases, dict)
Qt.QtCompat.QtHeaderView = type('QtHeaderView', tuple([_QtCompat]), attrs)
```
You can use these like the existing QtCompat functions by passing in the QHeaderView as the first argument `QtHeaderView.setSectionsMovable(header, False)`. However, because of the _QtCompat implementation you can also create a instance of QtHeaderView by passing in the header so you don't need to pass header into every function.
```python
headerComp = QtHeaderView(header)
headerComp.setSectionsMovable(False)
```
I think this can be useful especially if you have to call several compatibility functions on a item. However, I have found a couple of drawbacks. For static functions like QFileDialog.getOpenFileName you have to wrap the function in staticmethod or when you call this function on a instance it will pass the arguments wrong.

```python
attrs = dict(
    getOpenFileName = staticmethod(Qt._QtWidgets.QFileDialog.getOpenFileName),
    getOpenFileNames = staticmethod(Qt._QtWidgets.QFileDialog.getOpenFileNames),
    getSaveFileName = staticmethod(Qt._QtWidgets.QFileDialog.getSaveFileName),
)
Qt.QtCompat.QtFileDialog = type('QtFileDialog', tuple([_QtCompat]), attrs)
```
### Alternative
If we don't want to include the instancing feature, we can just pass object instead of _QtCompat.
```python
Qt.QtCompat.QtFileDialog = type('QtFileDialog', tuple([object]), attrs)
```
