### PR TITLE
Revert "QtCompat namespacing"

### DIFF
--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -264,7 +264,7 @@ Use compatibility wrapper.
 >>> app = QtWidgets.QApplication(sys.argv)
 >>> view = QtWidgets.QTreeWidget()
 >>> header = view.header()
->>> QtCompat.QHeaderView.setSectionResizeMode(header, QtWidgets.QHeaderView.Fixed)
+>>> QtCompat.setSectionResizeMode(header, QtWidgets.QHeaderView.Fixed)
 ```
 
 Or a conditional.
@@ -281,10 +281,6 @@ Or a conditional.
 ...   header.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
 ```
 
-Note: Qt.QtCompat.setSectionResizeMode is a older way this was handled and has been left in for now, but this will likely be removed in the future.
-
-<br>
-<br>
 
 #### QtWidgets.qApp
 

--- a/Qt.py
+++ b/Qt.py
@@ -43,8 +43,7 @@ import types
 import shutil
 import importlib
 
-
-__version__ = "1.1.0.b3"
+__version__ = "1.1.0.b2"
 
 # Enable support for `from Qt import *`
 __all__ = []
@@ -612,7 +611,7 @@ These members from the original submodule are misplaced relative PySide2
 
 """
 _misplaced_members = {
-    "PySide2": {
+    "pyside2": {
         "QtGui.QStringListModel": "QtCore.QStringListModel",
         "QtCore.Property": "QtCore.Property",
         "QtCore.Signal": "QtCore.Signal",
@@ -622,7 +621,7 @@ _misplaced_members = {
         "QtCore.QItemSelection": "QtCore.QItemSelection",
         "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
     },
-    "PyQt5": {
+    "pyqt5": {
         "QtCore.pyqtProperty": "QtCore.Property",
         "QtCore.pyqtSignal": "QtCore.Signal",
         "QtCore.pyqtSlot": "QtCore.Slot",
@@ -632,7 +631,7 @@ _misplaced_members = {
         "QtCore.QItemSelection": "QtCore.QItemSelection",
         "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
     },
-    "PySide": {
+    "pyside": {
         "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
         "QtGui.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
         "QtGui.QStringListModel": "QtCore.QStringListModel",
@@ -643,7 +642,7 @@ _misplaced_members = {
         "QtCore.Slot": "QtCore.Slot",
 
     },
-    "PyQt4": {
+    "pyqt4": {
         "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
         "QtGui.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
         "QtGui.QItemSelection": "QtCore.QItemSelection",
@@ -653,86 +652,6 @@ _misplaced_members = {
         "QtCore.pyqtSignal": "QtCore.Signal",
         "QtCore.pyqtSlot": "QtCore.Slot",
     }
-}
-
-""" Compatibility Members
-
-This dictionary is used to build Qt.QtCompat objects that provide a consistent
-interface for obsolete members, and differences in binding return values.
-
-{
-    "binding": {
-        "classname": {
-            "targetname": "binding_namespace",
-        }
-    }
-}
-"""
-_compatibility_members = {
-    "PySide2": {
-        "QHeaderView": {
-            "sectionsClickable": "_QtWidgets.QHeaderView.sectionsClickable",
-            "setSectionsClickable":
-                "_QtWidgets.QHeaderView.setSectionsClickable",
-            "sectionResizeMode": "_QtWidgets.QHeaderView.sectionResizeMode",
-            "setSectionResizeMode":
-                "_QtWidgets.QHeaderView.setSectionResizeMode",
-            "sectionsMovable": "_QtWidgets.QHeaderView.sectionsMovable",
-            "setSectionsMovable": "_QtWidgets.QHeaderView.setSectionsMovable",
-        },
-        "QFileDialog": {
-            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
-            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
-            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
-        },
-    },
-    "PyQt5": {
-        "QHeaderView": {
-            "sectionsClickable": "_QtWidgets.QHeaderView.sectionsClickable",
-            "setSectionsClickable":
-                "_QtWidgets.QHeaderView.setSectionsClickable",
-            "sectionResizeMode": "_QtWidgets.QHeaderView.sectionResizeMode",
-            "setSectionResizeMode":
-                "_QtWidgets.QHeaderView.setSectionResizeMode",
-            "sectionsMovable": "_QtWidgets.QHeaderView.sectionsMovable",
-            "setSectionsMovable": "_QtWidgets.QHeaderView.setSectionsMovable",
-        },
-        "QFileDialog": {
-            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
-            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
-            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
-        },
-    },
-    "PySide": {
-        "QHeaderView": {
-            "sectionsClickable": "_QtWidgets.QHeaderView.isClickable",
-            "setSectionsClickable": "_QtWidgets.QHeaderView.setClickable",
-            "sectionResizeMode": "_QtWidgets.QHeaderView.resizeMode",
-            "setSectionResizeMode": "_QtWidgets.QHeaderView.setResizeMode",
-            "sectionsMovable": "_QtWidgets.QHeaderView.isMovable",
-            "setSectionsMovable": "_QtWidgets.QHeaderView.setMovable",
-        },
-        "QFileDialog": {
-            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
-            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
-            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
-        },
-    },
-    "PyQt4": {
-        "QHeaderView": {
-            "sectionsClickable": "_QtWidgets.QHeaderView.isClickable",
-            "setSectionsClickable": "_QtWidgets.QHeaderView.setClickable",
-            "sectionResizeMode": "_QtWidgets.QHeaderView.resizeMode",
-            "setSectionResizeMode": "_QtWidgets.QHeaderView.setResizeMode",
-            "sectionsMovable": "_QtWidgets.QHeaderView.isMovable",
-            "setSectionsMovable": "_QtWidgets.QHeaderView.setMovable",
-        },
-        "QFileDialog": {
-            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
-            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
-            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
-        },
-    },
 }
 
 
@@ -745,9 +664,7 @@ def _apply_site_config():
         pass
     else:
         # Update _common_members with any changes made by QtSiteConfig
-        QtSiteConfig.update_members(_common_members, 'common')
-        QtSiteConfig.update_members(_misplaced_members, 'misplaced')
-        QtSiteConfig.update_members(_compatibility_members, 'compatibility')
+        QtSiteConfig.update_members(_common_members)
 
 
 def _new_module(name):
@@ -849,72 +766,6 @@ def _reassign_misplaced_members(binding):
         )
 
 
-def _build_compatibility_members(binding, decorators={}):
-    """ Parse `_compatibility_members` dict and construct _QtCompat classes
-    based on the underlying binding.
-
-    Arguments:
-        binding (str): Top level binding in _compatibility_members.
-        decorators (dict, optional): Provides the ability to decorate the
-            original Qt functions when needed by a binding. This can be used
-            to change the returned value to a standard value. The key should
-            match "targetname:binding_namespace". targetname is the function
-            name that the decorator will be applied to. binding_namespace
-            should match the binding_namespace of _compatibility_members.
-            The value is a decorator that will be called on the function
-            being bound.
-    """
-    # Allow optional site-level customization of the compatibility members.
-    # This method does not need to be implemented in QtSiteConfig.
-    try:
-        import QtSiteConfig
-    except ImportError:
-        pass
-    else:
-        if hasattr(QtSiteConfig, 'update_compatibility_decorators'):
-            QtSiteConfig.update_compatibility_decorators(binding, decorators)
-
-    for classname, bindings in _compatibility_members[binding].items():
-        attrs = {}
-        for target, binding in bindings.items():
-            namespaces = binding.split('.')
-            try:
-                src_object = getattr(Qt, namespaces[0])
-            except AttributeError as e:
-                _log("QtCompat: AttributeError: %s" % e)
-                # Skip reassignment of non-existing members.
-                # This can happen if a request was made to
-                # rename a member that didn't exist, for example
-                # if QtWidgets isn't available on the target platform.
-                continue
-            # Walk down any remaining namespace getting the object assuming
-            # that if the first namespace exists the rest will exist.
-            for namespace in namespaces[1:]:
-                src_object = getattr(src_object, namespace)
-
-            # To allow remapping a single Qt function to multiple QtCompat
-            # method names with unique decorators applied, we need a way
-            # to uniquely identify the decorator. For example, to map the
-            # getOpenFileName method to _QtWidgets.QFileDialog.getOpenFileName
-            # use: "getOpenFileName:_QtWidgets.QFileDialog.getOpenFileName"
-            decoratorId = '{target}:{binding}'.format(
-                target=target,
-                binding=binding,
-            )
-            # decorate the Qt function if a decorator was provided.
-            if decoratorId in decorators:
-                # staticmethod must be called on the decorated function to
-                # prevent a TypeError being raised when the decorated function
-                # is called.
-                src_object = staticmethod(decorators[decoratorId](src_object))
-
-            attrs[target] = src_object
-
-        # Create the QtCompat class and install it into the namespace
-        compat_class = type(classname, tuple([_QtCompat]), attrs)
-        setattr(Qt.QtCompat, classname, compat_class)
-
-
 def _pyside2():
     """Initialise PySide2
 
@@ -953,8 +804,7 @@ def _pyside2():
         Qt.QtCompat.setSectionResizeMode = \
             Qt._QtWidgets.QHeaderView.setSectionResizeMode
 
-    _reassign_misplaced_members("PySide2")
-    _build_compatibility_members("PySide2")
+    _reassign_misplaced_members("pyside2")
 
 
 def _pyside():
@@ -1000,8 +850,7 @@ def _pyside():
             )
         )
 
-    _reassign_misplaced_members("PySide")
-    _build_compatibility_members("PySide")
+    _reassign_misplaced_members("pyside")
 
 
 def _pyqt5():
@@ -1034,8 +883,7 @@ def _pyqt5():
         Qt.QtCompat.setSectionResizeMode = \
             Qt._QtWidgets.QHeaderView.setSectionResizeMode
 
-    _reassign_misplaced_members("PyQt5")
-    _build_compatibility_members('PyQt5')
+    _reassign_misplaced_members("pyqt5")
 
 
 def _pyqt4():
@@ -1115,31 +963,7 @@ def _pyqt4():
                 n)
         )
 
-    _reassign_misplaced_members("PyQt4")
-
-    # QFileDialog QtCompat decorator
-    def _standardizeQFileDialog(some_function):
-        """ decorator that makes PyQt4 return conform to other bindings
-        """
-        def wrapper(*args, **kwargs):
-            ret = (some_function(*args, **kwargs))
-            # PyQt4 only returns the selected filename
-            # force the return to conform to all other bindings
-            return (ret, '')
-        # preserve docstring and name of original function
-        wrapper.__doc__ = some_function.__doc__
-        wrapper.__name__ = some_function.__name__
-        return staticmethod(wrapper)
-
-    decorators = {
-        "getOpenFileName:_QtWidgets.QFileDialog.getOpenFileName":
-            _standardizeQFileDialog,
-        "getOpenFileNames:_QtWidgets.QFileDialog.getOpenFileNames":
-            _standardizeQFileDialog,
-        "getSaveFileName:_QtWidgets.QFileDialog.getSaveFileName":
-            _standardizeQFileDialog,
-    }
-    _build_compatibility_members('PyQt4', decorators)
+    _reassign_misplaced_members("pyqt4")
 
 
 def _none():
@@ -1264,10 +1088,6 @@ def _loadUi(uifile, baseinstance=None):
     else:
         raise NotImplementedError("No implementation available for loadUi")
 
-
-class _QtCompat(object):
-    """ Baseclass for QtCompat namespace objects."""
-    pass
 
 def _convert(lines):
     """Convert compiled .ui file from PySide2 to Qt.py
@@ -1417,8 +1237,7 @@ def _install():
             setattr(our_submodule, member, their_member)
 
     # Backwards compatibility
-    if hasattr(Qt.QtCompat, 'loadUi'):
-        Qt.QtCompat.load_ui = Qt.QtCompat.loadUi
+    Qt.QtCompat.load_ui = Qt.QtCompat.loadUi
 
 
 _install()

--- a/README.md
+++ b/README.md
@@ -128,38 +128,25 @@ All members of `Qt` stem directly from those available via PySide2, along with t
 'PyQt5'
 ```
 
-### Compatibility
-
 Qt.py also provides compatibility wrappers for critical functionality that differs across bindings, these can be found in the added `QtCompat` submodule.
 
 | Attribute                                 | Returns     | Description
 |:------------------------------------------|:------------|:------------
 | `loadUi(uifile=str, baseinstance=QWidget)`| `QObject`   | Minimal wrapper of PyQt4.loadUi and PySide equivalent
 | `translate(...)`        					| `function`  | Compatibility wrapper around [QCoreApplication.translate][]
+| `setSectionResizeMode()`					| `method`    | Compatibility wrapper around [QAbstractItemView.setSectionResizeMode][]
 | `wrapInstance(addr=long, type=QObject)`   | `QObject`   | Wrapper around `shiboken2.wrapInstance` and PyQt equivalent
 | `getCppPointer(object=QObject)`           | `long`      | Wrapper around `shiboken2.getCppPointer` and PyQt equivalent
 
 [QCoreApplication.translate]: https://doc.qt.io/qt-5/qcoreapplication.html#translate
+[QAbstractItemView.setSectionResizeMode]: https://doc.qt.io/qt-5/qheaderview.html#setSectionResizeMode
 
 **Example**
 
 ```python
 >>> from Qt import QtCompat
->>> QtCompat.loadUi
+>>> QtCompat.setSectionResizeMode
 ```
-
-#### Class specific compatibility objects
-
-Between Qt4 and Qt5 there have been many classes and class members that are obsolete. Under Qt.QtCompat there are many classes with names matching the classes they provide compatibility functions. These will match the PySide2 naming convention.
-
-```python
-from Qt import QtCore, QtWidgets, QtCompat
-header = QtWidgets.QHeaderView(QtCore.Qt.Horizontal)
-QtCompat.QHeaderView.setSectionsMovable(header, False)
-movable = QtCompat.QHeaderView.sectionsMovable(header)
-```
-
-This also covers inconsistencies between bindings. For example PyQt4's QFileDialog matches Qt4's return value of the selected. While all other bindings return the selected filename and the file filter the user used to select the file. `Qt.QtCompat.QFileDialog` ensures that getOpenFileName(s) and getSaveFileName always return the tuple.
 
 <br>
 
@@ -232,16 +219,15 @@ If you need to expose a module that isn't included in Qt.py by default or wish t
 
 ```python
 # QtSiteConfig.py
-def update_members(members, step):
-    """Called by Qt.py at run-time to modify the modules it makes available.
+def update_members(members):
+	"""Called by Qt.py at run-time to modify the modules it makes available.
 
     Arguments:
         members (dict): The members considered by Qt.py
-        step (str): Used to identify what members will be used for.
+
     """
 
-    if step == 'common':
-        members.pop("QtCore")
+    members.pop("QtCore")
 ```
 
 Finally, expose the module to Python.
@@ -387,7 +373,6 @@ Send us a pull-request with your studio here.
 - [CGRU](http://cgru.info/)
 - [MPC](http://www.moving-picture.com)
 - [Rising Sun Pictures](https://rsp.com.au)
-- [Blur Studio](http://www.blur.com)
 
 Presented at Siggraph 2016, BOF!
 

--- a/examples/QtSiteConfig/QtSiteConfig.py
+++ b/examples/QtSiteConfig/QtSiteConfig.py
@@ -1,56 +1,14 @@
-# Contrived example used for unit testing. For a more realistic example
-# see the README
+# Contrived example used for unit testing. This makes the QtCore module
+# not accessible. I chose this so it can be tested everywhere, for a more
+# realistic example see the README
 
 
-def update_members(members, step):
+def update_members(members):
     """This function is called by Qt.py to modify the modules it exposes.
 
     Arguments:
         members (dict): The members considered by Qt.py
-        step (str): Used to identify what members will be used for.
+
     """
 
-    if step == 'common':
-        # Contrived example used for unit testing. This makes the QtCore module
-        # not accessible. I chose this so it can be tested everywhere, for a
-        # more realistic example see the README
-        members.pop("QtCore")
-
-    elif step == 'compatibility':
-        # Create a QtCompat.QWidget compatibility class. This example is
-        # is used to provide a testable unittest
-        for binding in ("PySide2", "PyQt5", "PySide", "PyQt4"):
-            members[binding]["QWidget"] = {
-                # Simple remapping of QWidget.windowTitle
-                "windowTitleTest": "_QtWidgets.QWidget.windowTitle",
-                # Remap QWidget.windowTitle with a decorator that modifies
-                # the returned value.
-                "windowTitleDecorator": "_QtWidgets.QWidget.windowTitle",
-            }
-
-
-def update_compatibility_decorators(binding, decorators):
-    """ This function is called by Qt.py to modify the decorators applied to
-    QtCompat namespace objects. Defining this method is optional.
-
-    Arguments:
-        binding (str): The Qt binding being wrapped by Qt.py
-        decorators (dict): Maps specific decorator functions to
-            QtCompat namespace functions. See Qt._build_compatibility_members
-            for more info.
-    """
-
-    def _testFunction(some_function):
-        def wrapper(*args, **kwargs):
-            ret = some_function(*args, **kwargs)
-            # Modifies the returned value so we can test that the
-            # decorator works.
-            return 'Test: {}'.format(ret)
-        # preserve docstring and name of original function
-        wrapper.__doc__ = some_function.__doc__
-        wrapper.__name__ = some_function.__name__
-        return wrapper
-
-    # Install the decorator so it will be applied to the QtCompat object
-    decorators['windowTitleDecorator:_QtWidgets.QWidget.windowTitle'] = \
-        _testFunction
+    members.pop("QtCore")

--- a/examples/QtSiteConfig/README.md
+++ b/examples/QtSiteConfig/README.md
@@ -28,13 +28,9 @@ $ python main.py
 
 If you need to  you can also add modules that are not in the standard Qt.py.
 
-#### QtSiteConfig.py: Adding non-standard modules
-
-This example shows how to add a module that is not included by default with Qt.py.
-
 ```python
 def update_members_example(members):
-    """An example of adding Qsci to Qt.py.
+    """An example of adding QJsonDocument to QtCore and the Qsci.
     
     Remove "_example" from the function name to use this example.
 
@@ -44,115 +40,61 @@ def update_members_example(members):
 
     """
 
-    if step == 'common':
-        # Include Qsci module for scintilla lexer support.
-        members["Qsci"] = [
-            "QsciAPIs",
-            "QsciAbstractAPIs",
-            "QsciCommand",
-            "QsciCommandSet",
-            "QsciDocument",
-            "QsciLexer",
-            "QsciLexerAVS",
-            "QsciLexerBash",
-            "QsciLexerBatch",
-            "QsciLexerCMake",
-            "QsciLexerCPP",
-            "QsciLexerCSS",
-            "QsciLexerCSharp",
-            "QsciLexerCoffeeScript",
-            "QsciLexerCustom",
-            "QsciLexerD",
-            "QsciLexerDiff",
-            "QsciLexerFortran",
-            "QsciLexerFortran77",
-            "QsciLexerHTML",
-            "QsciLexerIDL",
-            "QsciLexerJSON",
-            "QsciLexerJava",
-            "QsciLexerJavaScript",
-            "QsciLexerLua",
-            "QsciLexerMakefile",
-            "QsciLexerMarkdown",
-            "QsciLexerMatlab",
-            "QsciLexerOctave",
-            "QsciLexerPO",
-            "QsciLexerPOV",
-            "QsciLexerPascal",
-            "QsciLexerPerl",
-            "QsciLexerPostScript",
-            "QsciLexerProperties",
-            "QsciLexerPython",
-            "QsciLexerRuby",
-            "QsciLexerSQL",
-            "QsciLexerSpice",
-            "QsciLexerTCL",
-            "QsciLexerTeX",
-            "QsciLexerVHDL",
-            "QsciLexerVerilog",
-            "QsciLexerXML",
-            "QsciLexerYAML",
-            "QsciMacro",
-            "QsciPrinter",
-            "QsciScintilla",
-            "QsciScintillaBase",
-            "QsciStyle",
-            "QsciStyledText",
-        ]
-```
+    # Include QJsonDocument module
+    members["QtCore"].append("QJsonDocument")
 
-
-#### QtSiteConfig.py: Standardizing PyQt4 functionality
-
-This example reproduces functionality already in Qt.py but it provides a good example of what is necessary to create your QtCompat namespaces with custom function decorators to change how the source function runs.
-
-```python
-def update_members_example(members, step):
-    """This function is called by Qt.py to modify the modules it exposes.
-
-    Remove "_example" from the function name to use this example.
-
-    Arguments:
-        members (dict): The members considered by Qt.py
-        step (str): Used to identify what members will be used for.
-    """
-    if step == 'compatibility':
-        members['PyQt4']["QFileDialog"] = {
-            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
-            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
-            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
-        }
-
-def update_compatibility_decorators_example(binding, decorators):
-    """ This function is called by Qt.py to modify the decorators applied to
-    QtCompat namespace objects. Defining this method is optional.
-
-    Remove "_example" from the function name to use this example.
-
-    Arguments:
-        binding (str): The Qt binding being wrapped by Qt.py
-        decorators (dict): Maps specific decorator functions to
-            QtCompat namespace functions. See Qt._build_compatibility_members
-            for more info.
-    """
-    if binding == 'PyQt4':
-        # QFileDialog QtCompat decorator
-        def _standardizeQFileDialog(some_function):
-            """ decorator that makes PyQt4 return conform to other bindings
-            """
-            def wrapper(*args, **kwargs):
-                ret = some_function(*args, **kwargs)
-                # PyQt4 only returns the selected filename
-                # force the return to conform to all other bindings
-                return (ret, '')
-            # preserve docstring and name of original function
-            wrapper.__doc__ = some_function.__doc__
-            wrapper.__name__ = some_function.__name__
-            return wrapper
-        decorators["getOpenFileName:_QtWidgets.QFileDialog.getOpenFileName"] = \
-            _standardizeQFileDialog
-        decorators["getOpenFileNames:_QtWidgets.QFileDialog.getOpenFileNames"] = \
-            _standardizeQFileDialog
-        decorators["getSaveFileName:_QtWidgets.QFileDialog.getSaveFileName"] = \
-            _standardizeQFileDialog
+    # Include Qsci module for scintilla lexer support.
+    members["Qsci"] = [
+        "QsciAPIs",
+        "QsciAbstractAPIs",
+        "QsciCommand",
+        "QsciCommandSet",
+        "QsciDocument",
+        "QsciLexer",
+        "QsciLexerAVS",
+        "QsciLexerBash",
+        "QsciLexerBatch",
+        "QsciLexerCMake",
+        "QsciLexerCPP",
+        "QsciLexerCSS",
+        "QsciLexerCSharp",
+        "QsciLexerCoffeeScript",
+        "QsciLexerCustom",
+        "QsciLexerD",
+        "QsciLexerDiff",
+        "QsciLexerFortran",
+        "QsciLexerFortran77",
+        "QsciLexerHTML",
+        "QsciLexerIDL",
+        "QsciLexerJSON",
+        "QsciLexerJava",
+        "QsciLexerJavaScript",
+        "QsciLexerLua",
+        "QsciLexerMakefile",
+        "QsciLexerMarkdown",
+        "QsciLexerMatlab",
+        "QsciLexerOctave",
+        "QsciLexerPO",
+        "QsciLexerPOV",
+        "QsciLexerPascal",
+        "QsciLexerPerl",
+        "QsciLexerPostScript",
+        "QsciLexerProperties",
+        "QsciLexerPython",
+        "QsciLexerRuby",
+        "QsciLexerSQL",
+        "QsciLexerSpice",
+        "QsciLexerTCL",
+        "QsciLexerTeX",
+        "QsciLexerVHDL",
+        "QsciLexerVerilog",
+        "QsciLexerXML",
+        "QsciLexerYAML",
+        "QsciMacro",
+        "QsciPrinter",
+        "QsciScintilla",
+        "QsciScintillaBase",
+        "QsciStyle",
+        "QsciStyledText",
+    ]
 ```

--- a/examples/QtSiteConfig/main.py
+++ b/examples/QtSiteConfig/main.py
@@ -25,24 +25,6 @@ def test():
         # Suppress 'Qt.QtCore' imported but unused warning
         QtCore
 
-    # Test _compatibility_members is applied correctly
-    title = 'Test Widget'
-    from Qt import QtWidgets, QtCompat
-    app = QtWidgets.QApplication(sys.argv)
-    win = QtWidgets.QWidget()
-    win.setWindowTitle(title)
-
-    # Verify that our simple remapping of QWidget.windowTitle works
-    assert QtCompat.QWidget.windowTitleTest(win) == title, \
-        "Non-decorated function was added to QtCompat.QWidget"
-    # Verify that our decorated remapping of QWidget.windowTitle works
-    check = 'Test: {}'.format(title)
-    assert QtCompat.QWidget.windowTitleDecorator(win) == check, \
-        "Decorated function was added to QtCompat.QWidget"
-
-    # Suppress 'app' imported but unused warning
-    app
-
 
 if __name__ == '__main__':
     test()

--- a/tests.py
+++ b/tests.py
@@ -420,23 +420,6 @@ def test_binding_states():
     assert Qt.IsPyQt4 == binding("PyQt4")
 
 
-def test_qtcompat_base_class():
-    """Tests to ensure the QtCompat namespace object works as expected"""
-    import sys
-    import Qt
-    from Qt import QtWidgets
-    from Qt import QtCompat
-    app = QtWidgets.QApplication(sys.argv)
-    # suppress `local variable 'app' is assigned to but never used`
-    app
-    header = QtWidgets.QHeaderView(Qt.QtCore.Qt.Horizontal)
-
-    # Spot check compatibility functions
-    QtCompat.QHeaderView.setSectionsMovable(header, False)
-    assert QtCompat.QHeaderView.sectionsMovable(header) is False
-    QtCompat.QHeaderView.setSectionsMovable(header, True)
-    assert QtCompat.QHeaderView.sectionsMovable(header) is True
-
 def test_cli():
     """Qt.py is available from the command-line"""
     env = os.environ.copy()


### PR DESCRIPTION
I noticed that this breaks backwards compatibility with `QtSiteConfig` and that there are no signs of compatibility not breaking again once we continue to add members to it.

- [Before](https://github.com/mottosso/Qt.py/blob/52e3c073c1baeef2c871a6e546a93458e84590a8/Qt.py#L611)
    `QtSiteConfig.update_members(_common_members)`
- [After](https://github.com/mottosso/Qt.py/blob/2196efcaa9f8a13dab55d38433b4f14f7da6d957/Qt.py#L748)
`QtSiteConfig.update_members(_common_members, 'common')`

In practice, anyone who has used `QtSiteConfig` for anything will have their code broken. That's no good, the last thing I want is for users to fear updating their Qt.py release and for that we must maintain *complete* backwards compatibility until a new major release (i.e. 2.0) is made.

@MHendricks I'd suggest we either remove any alteration to QtSiteConfig, or find a way of altering it in a way that doesn't break backwards compatibility.