### PR TITLE
Make QtSiteConfig.update_members backwards compatible

### DIFF
--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -264,7 +264,7 @@ Use compatibility wrapper.
 >>> app = QtWidgets.QApplication(sys.argv)
 >>> view = QtWidgets.QTreeWidget()
 >>> header = view.header()
->>> QtCompat.setSectionResizeMode(header, QtWidgets.QHeaderView.Fixed)
+>>> QtCompat.QHeaderView.setSectionResizeMode(header, QtWidgets.QHeaderView.Fixed)
 ```
 
 Or a conditional.
@@ -281,6 +281,10 @@ Or a conditional.
 ...   header.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
 ```
 
+Note: Qt.QtCompat.setSectionResizeMode is a older way this was handled and has been left in for now, but this will likely be removed in the future.
+
+<br>
+<br>
 
 #### QtWidgets.qApp
 

--- a/Qt.py
+++ b/Qt.py
@@ -1129,7 +1129,7 @@ def _pyqt4():
 
     decorators = {
         "QFileDialog": {
-            "getOpenFileName":_standardizeQFileDialog,
+            "getOpenFileName": _standardizeQFileDialog,
             "getOpenFileNames": _standardizeQFileDialog,
             "getSaveFileName": _standardizeQFileDialog,
         }

--- a/Qt.py
+++ b/Qt.py
@@ -748,11 +748,14 @@ def _apply_site_config():
         try:
             QtSiteConfig.update_members(_common_members, 'common')
             QtSiteConfig.update_members(_misplaced_members, 'misplaced')
-            QtSiteConfig.update_members(_compatibility_members, 'compatibility')
+            QtSiteConfig.update_members(
+                _compatibility_members,
+                'compatibility')
         except TypeError:
             # Handle the old method signature so we don't break backwards
             # compatibility with previous versions of QtSiteConfig
-            _log("QtSiteConfig.update_members now takes (dict, step) arguments")
+            _log(
+                "QtSiteConfig.update_members now takes (dict, step) arguments")
             QtSiteConfig.update_members(_common_members)
 
 

--- a/Qt.py
+++ b/Qt.py
@@ -745,9 +745,15 @@ def _apply_site_config():
         pass
     else:
         # Update _common_members with any changes made by QtSiteConfig
-        QtSiteConfig.update_members(_common_members, 'common')
-        QtSiteConfig.update_members(_misplaced_members, 'misplaced')
-        QtSiteConfig.update_members(_compatibility_members, 'compatibility')
+        try:
+            QtSiteConfig.update_members(_common_members, 'common')
+            QtSiteConfig.update_members(_misplaced_members, 'misplaced')
+            QtSiteConfig.update_members(_compatibility_members, 'compatibility')
+        except TypeError:
+            # Handle the old method signature so we don't break backwards
+            # compatibility with previous versions of QtSiteConfig
+            _log("QtSiteConfig.update_members now takes (dict, step) arguments")
+            QtSiteConfig.update_members(_common_members)
 
 
 def _new_module(name):

--- a/Qt.py
+++ b/Qt.py
@@ -745,18 +745,9 @@ def _apply_site_config():
         pass
     else:
         # Update _common_members with any changes made by QtSiteConfig
-        try:
-            QtSiteConfig.update_members(_common_members, 'common')
-            QtSiteConfig.update_members(_misplaced_members, 'misplaced')
-            QtSiteConfig.update_members(
-                _compatibility_members,
-                'compatibility')
-        except TypeError:
-            # Handle the old method signature so we don't break backwards
-            # compatibility with previous versions of QtSiteConfig
-            _log(
-                "QtSiteConfig.update_members now takes (dict, step) arguments")
-            QtSiteConfig.update_members(_common_members)
+        QtSiteConfig.update_members(_common_members, 'common')
+        QtSiteConfig.update_members(_misplaced_members, 'misplaced')
+        QtSiteConfig.update_members(_compatibility_members, 'compatibility')
 
 
 def _new_module(name):

--- a/Qt.py
+++ b/Qt.py
@@ -1118,10 +1118,11 @@ def _pyqt4():
         """
         def wrapper(*args, **kwargs):
             ret = (some_function(*args, **kwargs))
-            # PyQt4 only returns the selected filename
-            # force the return to conform to all other bindings
+            # PyQt4 only returns the selected filename, force it to a
+            # standard return of the selected filename, and a empty string
+            # for the selected filter
             return (ret, '')
-        # preserve docstring and name of original function
+        # preserve docstring and name of original method
         wrapper.__doc__ = some_function.__doc__
         wrapper.__name__ = some_function.__name__
         return wrapper

--- a/Qt.py
+++ b/Qt.py
@@ -1129,14 +1129,14 @@ def _pyqt4():
         # preserve docstring and name of original function
         wrapper.__doc__ = some_function.__doc__
         wrapper.__name__ = some_function.__name__
-        return staticmethod(wrapper)
+        return wrapper
 
     decorators = {
-        "getOpenFileName:_QtWidgets.QFileDialog.getOpenFileName":
+        "getOpenFileName:QtWidgets.QFileDialog.getOpenFileName":
             _standardizeQFileDialog,
-        "getOpenFileNames:_QtWidgets.QFileDialog.getOpenFileNames":
+        "getOpenFileNames:QtWidgets.QFileDialog.getOpenFileNames":
             _standardizeQFileDialog,
-        "getSaveFileName:_QtWidgets.QFileDialog.getSaveFileName":
+        "getSaveFileName:QtWidgets.QFileDialog.getSaveFileName":
             _standardizeQFileDialog,
     }
     _build_compatibility_members('PyQt4', decorators)

--- a/Qt.py
+++ b/Qt.py
@@ -671,66 +671,66 @@ interface for obsolete members, and differences in binding return values.
 _compatibility_members = {
     "PySide2": {
         "QHeaderView": {
-            "sectionsClickable": "_QtWidgets.QHeaderView.sectionsClickable",
+            "sectionsClickable": "QtWidgets.QHeaderView.sectionsClickable",
             "setSectionsClickable":
-                "_QtWidgets.QHeaderView.setSectionsClickable",
-            "sectionResizeMode": "_QtWidgets.QHeaderView.sectionResizeMode",
+                "QtWidgets.QHeaderView.setSectionsClickable",
+            "sectionResizeMode": "QtWidgets.QHeaderView.sectionResizeMode",
             "setSectionResizeMode":
-                "_QtWidgets.QHeaderView.setSectionResizeMode",
-            "sectionsMovable": "_QtWidgets.QHeaderView.sectionsMovable",
-            "setSectionsMovable": "_QtWidgets.QHeaderView.setSectionsMovable",
+                "QtWidgets.QHeaderView.setSectionResizeMode",
+            "sectionsMovable": "QtWidgets.QHeaderView.sectionsMovable",
+            "setSectionsMovable": "QtWidgets.QHeaderView.setSectionsMovable",
         },
         "QFileDialog": {
-            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
-            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
-            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
         },
     },
     "PyQt5": {
         "QHeaderView": {
-            "sectionsClickable": "_QtWidgets.QHeaderView.sectionsClickable",
+            "sectionsClickable": "QtWidgets.QHeaderView.sectionsClickable",
             "setSectionsClickable":
-                "_QtWidgets.QHeaderView.setSectionsClickable",
-            "sectionResizeMode": "_QtWidgets.QHeaderView.sectionResizeMode",
+                "QtWidgets.QHeaderView.setSectionsClickable",
+            "sectionResizeMode": "QtWidgets.QHeaderView.sectionResizeMode",
             "setSectionResizeMode":
-                "_QtWidgets.QHeaderView.setSectionResizeMode",
-            "sectionsMovable": "_QtWidgets.QHeaderView.sectionsMovable",
-            "setSectionsMovable": "_QtWidgets.QHeaderView.setSectionsMovable",
+                "QtWidgets.QHeaderView.setSectionResizeMode",
+            "sectionsMovable": "QtWidgets.QHeaderView.sectionsMovable",
+            "setSectionsMovable": "QtWidgets.QHeaderView.setSectionsMovable",
         },
         "QFileDialog": {
-            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
-            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
-            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
         },
     },
     "PySide": {
         "QHeaderView": {
-            "sectionsClickable": "_QtWidgets.QHeaderView.isClickable",
-            "setSectionsClickable": "_QtWidgets.QHeaderView.setClickable",
-            "sectionResizeMode": "_QtWidgets.QHeaderView.resizeMode",
-            "setSectionResizeMode": "_QtWidgets.QHeaderView.setResizeMode",
-            "sectionsMovable": "_QtWidgets.QHeaderView.isMovable",
-            "setSectionsMovable": "_QtWidgets.QHeaderView.setMovable",
+            "sectionsClickable": "QtWidgets.QHeaderView.isClickable",
+            "setSectionsClickable": "QtWidgets.QHeaderView.setClickable",
+            "sectionResizeMode": "QtWidgets.QHeaderView.resizeMode",
+            "setSectionResizeMode": "QtWidgets.QHeaderView.setResizeMode",
+            "sectionsMovable": "QtWidgets.QHeaderView.isMovable",
+            "setSectionsMovable": "QtWidgets.QHeaderView.setMovable",
         },
         "QFileDialog": {
-            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
-            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
-            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
         },
     },
     "PyQt4": {
         "QHeaderView": {
-            "sectionsClickable": "_QtWidgets.QHeaderView.isClickable",
-            "setSectionsClickable": "_QtWidgets.QHeaderView.setClickable",
-            "sectionResizeMode": "_QtWidgets.QHeaderView.resizeMode",
-            "setSectionResizeMode": "_QtWidgets.QHeaderView.setResizeMode",
-            "sectionsMovable": "_QtWidgets.QHeaderView.isMovable",
-            "setSectionsMovable": "_QtWidgets.QHeaderView.setMovable",
+            "sectionsClickable": "QtWidgets.QHeaderView.isClickable",
+            "setSectionsClickable": "QtWidgets.QHeaderView.setClickable",
+            "sectionResizeMode": "QtWidgets.QHeaderView.resizeMode",
+            "setSectionResizeMode": "QtWidgets.QHeaderView.setResizeMode",
+            "sectionsMovable": "QtWidgets.QHeaderView.isMovable",
+            "setSectionsMovable": "QtWidgets.QHeaderView.setMovable",
         },
         "QFileDialog": {
-            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
-            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
-            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
         },
     },
 }
@@ -879,7 +879,7 @@ def _build_compatibility_members(binding, decorators={}):
         for target, binding in bindings.items():
             namespaces = binding.split('.')
             try:
-                src_object = getattr(Qt, namespaces[0])
+                src_object = getattr(Qt, "_" + namespaces[0])
             except AttributeError as e:
                 _log("QtCompat: AttributeError: %s" % e)
                 # Skip reassignment of non-existing members.
@@ -895,8 +895,8 @@ def _build_compatibility_members(binding, decorators={}):
             # To allow remapping a single Qt function to multiple QtCompat
             # method names with unique decorators applied, we need a way
             # to uniquely identify the decorator. For example, to map the
-            # getOpenFileName method to _QtWidgets.QFileDialog.getOpenFileName
-            # use: "getOpenFileName:_QtWidgets.QFileDialog.getOpenFileName"
+            # getOpenFileName method to QtWidgets.QFileDialog.getOpenFileName
+            # use: "getOpenFileName:QtWidgets.QFileDialog.getOpenFileName"
             decoratorId = '{target}:{binding}'.format(
                 target=target,
                 binding=binding,

--- a/Qt.py
+++ b/Qt.py
@@ -744,10 +744,16 @@ def _apply_site_config():
         # to _common_members are needed.
         pass
     else:
-        # Update _common_members with any changes made by QtSiteConfig
-        QtSiteConfig.update_members(_common_members, 'common')
-        QtSiteConfig.update_members(_misplaced_members, 'misplaced')
-        QtSiteConfig.update_members(_compatibility_members, 'compatibility')
+        # Provide the ability to modify the dicts used to build Qt.py
+        if hasattr(QtSiteConfig, 'update_members'):
+            QtSiteConfig.update_members(_common_members)
+
+        if hasattr(QtSiteConfig, 'update_misplaced_members'):
+            QtSiteConfig.update_misplaced_members(members=_misplaced_members)
+
+        if hasattr(QtSiteConfig, 'update_compatibility_members'):
+            QtSiteConfig.update_compatibility_members(
+                members=_compatibility_members)
 
 
 def _new_module(name):

--- a/README.md
+++ b/README.md
@@ -128,25 +128,38 @@ All members of `Qt` stem directly from those available via PySide2, along with t
 'PyQt5'
 ```
 
+### Compatibility
+
 Qt.py also provides compatibility wrappers for critical functionality that differs across bindings, these can be found in the added `QtCompat` submodule.
 
 | Attribute                                 | Returns     | Description
 |:------------------------------------------|:------------|:------------
 | `loadUi(uifile=str, baseinstance=QWidget)`| `QObject`   | Minimal wrapper of PyQt4.loadUi and PySide equivalent
 | `translate(...)`        					| `function`  | Compatibility wrapper around [QCoreApplication.translate][]
-| `setSectionResizeMode()`					| `method`    | Compatibility wrapper around [QAbstractItemView.setSectionResizeMode][]
 | `wrapInstance(addr=long, type=QObject)`   | `QObject`   | Wrapper around `shiboken2.wrapInstance` and PyQt equivalent
 | `getCppPointer(object=QObject)`           | `long`      | Wrapper around `shiboken2.getCppPointer` and PyQt equivalent
 
 [QCoreApplication.translate]: https://doc.qt.io/qt-5/qcoreapplication.html#translate
-[QAbstractItemView.setSectionResizeMode]: https://doc.qt.io/qt-5/qheaderview.html#setSectionResizeMode
 
 **Example**
 
 ```python
 >>> from Qt import QtCompat
->>> QtCompat.setSectionResizeMode
+>>> QtCompat.loadUi
 ```
+
+#### Class specific compatibility objects
+
+Between Qt4 and Qt5 there have been many classes and class members that are obsolete. Under Qt.QtCompat there are many classes with names matching the classes they provide compatibility functions. These will match the PySide2 naming convention.
+
+```python
+from Qt import QtCore, QtWidgets, QtCompat
+header = QtWidgets.QHeaderView(QtCore.Qt.Horizontal)
+QtCompat.QHeaderView.setSectionsMovable(header, False)
+movable = QtCompat.QHeaderView.sectionsMovable(header)
+```
+
+This also covers inconsistencies between bindings. For example PyQt4's QFileDialog matches Qt4's return value of the selected. While all other bindings return the selected filename and the file filter the user used to select the file. `Qt.QtCompat.QFileDialog` ensures that getOpenFileName(s) and getSaveFileName always return the tuple.
 
 <br>
 
@@ -219,15 +232,16 @@ If you need to expose a module that isn't included in Qt.py by default or wish t
 
 ```python
 # QtSiteConfig.py
-def update_members(members):
-	"""Called by Qt.py at run-time to modify the modules it makes available.
+def update_members(members, step):
+    """Called by Qt.py at run-time to modify the modules it makes available.
 
     Arguments:
         members (dict): The members considered by Qt.py
-
+        step (str): Used to identify what members will be used for.
     """
 
-    members.pop("QtCore")
+    if step == 'common':
+        members.pop("QtCore")
 ```
 
 Finally, expose the module to Python.
@@ -373,6 +387,7 @@ Send us a pull-request with your studio here.
 - [CGRU](http://cgru.info/)
 - [MPC](http://www.moving-picture.com)
 - [Rising Sun Pictures](https://rsp.com.au)
+- [Blur Studio](http://www.blur.com)
 
 Presented at Siggraph 2016, BOF!
 

--- a/README.md
+++ b/README.md
@@ -232,16 +232,13 @@ If you need to expose a module that isn't included in Qt.py by default or wish t
 
 ```python
 # QtSiteConfig.py
-def update_members(members, step):
+def update_members(members):
     """Called by Qt.py at run-time to modify the modules it makes available.
 
     Arguments:
         members (dict): The members considered by Qt.py
-        step (str): Used to identify what members will be used for.
     """
-
-    if step == 'common':
-        members.pop("QtCore")
+    members.pop("QtCore")
 ```
 
 Finally, expose the module to Python.

--- a/examples/QtSiteConfig/QtSiteConfig.py
+++ b/examples/QtSiteConfig/QtSiteConfig.py
@@ -43,6 +43,9 @@ def update_compatibility_members(members):
             # the returned value.
             "windowTitleDecorator": "QtWidgets.QWidget.windowTitle",
         }
+        members[binding]["QMainWindow"] = {
+            "windowTitleDecorator": "QtWidgets.QMainWindow.windowTitle"
+        }
 
 def update_compatibility_decorators(binding, decorators):
     """ This optional function is called by Qt.py to modify the decorators
@@ -51,11 +54,11 @@ def update_compatibility_decorators(binding, decorators):
     Arguments:
         binding (str): The Qt binding being wrapped by Qt.py
         decorators (dict): Maps specific decorator functions to
-            QtCompat namespace functions. See Qt._build_compatibility_members
+            QtCompat namespace methods. See Qt._build_compatibility_members
             for more info.
     """
 
-    def _testFunction(some_function):
+    def _widgetDecorator(some_function):
         def wrapper(*args, **kwargs):
             ret = some_function(*args, **kwargs)
             # Modifies the returned value so we can test that the
@@ -66,6 +69,18 @@ def update_compatibility_decorators(binding, decorators):
         wrapper.__name__ = some_function.__name__
         return wrapper
 
-    # Install the decorator so it will be applied to the QtCompat object
-    decorators["windowTitleDecorator:QtWidgets.QWidget.windowTitle"] = \
-        _testFunction
+    # Assign a different decorator for the same method name on each class
+    def _mainWindowDecorator(some_function):
+        def wrapper(*args, **kwargs):
+            ret = some_function(*args, **kwargs)
+            # Modifies the returned value so we can test that the
+            # decorator works.
+            return "QMainWindow Test: {}".format(ret)
+        # preserve docstring and name of original function
+        wrapper.__doc__ = some_function.__doc__
+        wrapper.__name__ = some_function.__name__
+        return wrapper
+    decorators.setdefault("QWidget", {})["windowTitleDecorator"] = \
+        _widgetDecorator
+    decorators.setdefault("QMainWindow", {})["windowTitleDecorator"] = \
+        _mainWindowDecorator

--- a/examples/QtSiteConfig/QtSiteConfig.py
+++ b/examples/QtSiteConfig/QtSiteConfig.py
@@ -14,6 +14,7 @@ def update_members(members):
     # more realistic example see the README
     members.pop("QtCore")
 
+
 def update_misplaced_members(members):
     """This optional function is called by Qt.py to standardize the location
     and naming of exposed classes.
@@ -25,6 +26,7 @@ def update_misplaced_members(members):
     members["PyQt5"]["QtGui.QColor"] = "QtGui.QColorTest"
     members["PySide"]["QtGui.QColor"] = "QtGui.QColorTest"
     members["PyQt4"]["QtGui.QColor"] = "QtGui.QColorTest"
+
 
 def update_compatibility_members(members):
     """This optional function is called by Qt.py to modify the structure of
@@ -46,6 +48,7 @@ def update_compatibility_members(members):
         members[binding]["QMainWindow"] = {
             "windowTitleDecorator": "QtWidgets.QMainWindow.windowTitle"
         }
+
 
 def update_compatibility_decorators(binding, decorators):
     """ This optional function is called by Qt.py to modify the decorators

--- a/examples/QtSiteConfig/QtSiteConfig.py
+++ b/examples/QtSiteConfig/QtSiteConfig.py
@@ -1,14 +1,56 @@
-# Contrived example used for unit testing. This makes the QtCore module
-# not accessible. I chose this so it can be tested everywhere, for a more
-# realistic example see the README
+# Contrived example used for unit testing. For a more realistic example
+# see the README
 
 
-def update_members(members):
+def update_members(members, step):
     """This function is called by Qt.py to modify the modules it exposes.
 
     Arguments:
         members (dict): The members considered by Qt.py
-
+        step (str): Used to identify what members will be used for.
     """
 
-    members.pop("QtCore")
+    if step == 'common':
+        # Contrived example used for unit testing. This makes the QtCore module
+        # not accessible. I chose this so it can be tested everywhere, for a
+        # more realistic example see the README
+        members.pop("QtCore")
+
+    elif step == 'compatibility':
+        # Create a QtCompat.QWidget compatibility class. This example is
+        # is used to provide a testable unittest
+        for binding in ("PySide2", "PyQt5", "PySide", "PyQt4"):
+            members[binding]["QWidget"] = {
+                # Simple remapping of QWidget.windowTitle
+                "windowTitleTest": "_QtWidgets.QWidget.windowTitle",
+                # Remap QWidget.windowTitle with a decorator that modifies
+                # the returned value.
+                "windowTitleDecorator": "_QtWidgets.QWidget.windowTitle",
+            }
+
+
+def update_compatibility_decorators(binding, decorators):
+    """ This function is called by Qt.py to modify the decorators applied to
+    QtCompat namespace objects. Defining this method is optional.
+
+    Arguments:
+        binding (str): The Qt binding being wrapped by Qt.py
+        decorators (dict): Maps specific decorator functions to
+            QtCompat namespace functions. See Qt._build_compatibility_members
+            for more info.
+    """
+
+    def _testFunction(some_function):
+        def wrapper(*args, **kwargs):
+            ret = some_function(*args, **kwargs)
+            # Modifies the returned value so we can test that the
+            # decorator works.
+            return 'Test: {}'.format(ret)
+        # preserve docstring and name of original function
+        wrapper.__doc__ = some_function.__doc__
+        wrapper.__name__ = some_function.__name__
+        return wrapper
+
+    # Install the decorator so it will be applied to the QtCompat object
+    decorators['windowTitleDecorator:_QtWidgets.QWidget.windowTitle'] = \
+        _testFunction

--- a/examples/QtSiteConfig/QtSiteConfig.py
+++ b/examples/QtSiteConfig/QtSiteConfig.py
@@ -22,10 +22,10 @@ def update_members(members, step):
         for binding in ("PySide2", "PyQt5", "PySide", "PyQt4"):
             members[binding]["QWidget"] = {
                 # Simple remapping of QWidget.windowTitle
-                "windowTitleTest": "_QtWidgets.QWidget.windowTitle",
+                "windowTitleTest": "QtWidgets.QWidget.windowTitle",
                 # Remap QWidget.windowTitle with a decorator that modifies
                 # the returned value.
-                "windowTitleDecorator": "_QtWidgets.QWidget.windowTitle",
+                "windowTitleDecorator": "QtWidgets.QWidget.windowTitle",
             }
 
 
@@ -52,5 +52,5 @@ def update_compatibility_decorators(binding, decorators):
         return wrapper
 
     # Install the decorator so it will be applied to the QtCompat object
-    decorators['windowTitleDecorator:_QtWidgets.QWidget.windowTitle'] = \
+    decorators['windowTitleDecorator:QtWidgets.QWidget.windowTitle'] = \
         _testFunction

--- a/examples/QtSiteConfig/QtSiteConfig.py
+++ b/examples/QtSiteConfig/QtSiteConfig.py
@@ -2,36 +2,51 @@
 # see the README
 
 
-def update_members(members, step):
-    """This function is called by Qt.py to modify the modules it exposes.
+def update_members(members):
+    """This optional function is called by Qt.py to modify the modules exposed.
 
     Arguments:
         members (dict): The members considered by Qt.py
-        step (str): Used to identify what members will be used for.
     """
 
-    if step == 'common':
-        # Contrived example used for unit testing. This makes the QtCore module
-        # not accessible. I chose this so it can be tested everywhere, for a
-        # more realistic example see the README
-        members.pop("QtCore")
+    # Contrived example used for unit testing. This makes the QtCore module
+    # not accessible. I chose this so it can be tested everywhere, for a
+    # more realistic example see the README
+    members.pop("QtCore")
 
-    elif step == 'compatibility':
-        # Create a QtCompat.QWidget compatibility class. This example is
-        # is used to provide a testable unittest
-        for binding in ("PySide2", "PyQt5", "PySide", "PyQt4"):
-            members[binding]["QWidget"] = {
-                # Simple remapping of QWidget.windowTitle
-                "windowTitleTest": "QtWidgets.QWidget.windowTitle",
-                # Remap QWidget.windowTitle with a decorator that modifies
-                # the returned value.
-                "windowTitleDecorator": "QtWidgets.QWidget.windowTitle",
-            }
+def update_misplaced_members(members):
+    """This optional function is called by Qt.py to standardize the location
+    and naming of exposed classes.
 
+    Arguments:
+        members (dict): The members considered by Qt.py
+    """
+    members["PySide2"]["QtGui.QColor"] = "QtGui.QColorTest"
+    members["PyQt5"]["QtGui.QColor"] = "QtGui.QColorTest"
+    members["PySide"]["QtGui.QColor"] = "QtGui.QColorTest"
+    members["PyQt4"]["QtGui.QColor"] = "QtGui.QColorTest"
+
+def update_compatibility_members(members):
+    """This optional function is called by Qt.py to modify the structure of
+    QtCompat namespace classes.
+
+    Arguments:
+        members (dict): The members considered by Qt.py
+    """
+    # Create a QtCompat.QWidget compatibility class. This example is
+    # is used to provide a testable unittest
+    for binding in ("PySide2", "PyQt5", "PySide", "PyQt4"):
+        members[binding]["QWidget"] = {
+            # Simple remapping of QWidget.windowTitle
+            "windowTitleTest": "QtWidgets.QWidget.windowTitle",
+            # Remap QWidget.windowTitle with a decorator that modifies
+            # the returned value.
+            "windowTitleDecorator": "QtWidgets.QWidget.windowTitle",
+        }
 
 def update_compatibility_decorators(binding, decorators):
-    """ This function is called by Qt.py to modify the decorators applied to
-    QtCompat namespace objects. Defining this method is optional.
+    """ This optional function is called by Qt.py to modify the decorators
+    applied to QtCompat namespace objects.
 
     Arguments:
         binding (str): The Qt binding being wrapped by Qt.py
@@ -45,12 +60,12 @@ def update_compatibility_decorators(binding, decorators):
             ret = some_function(*args, **kwargs)
             # Modifies the returned value so we can test that the
             # decorator works.
-            return 'Test: {}'.format(ret)
+            return "Test: {}".format(ret)
         # preserve docstring and name of original function
         wrapper.__doc__ = some_function.__doc__
         wrapper.__name__ = some_function.__name__
         return wrapper
 
     # Install the decorator so it will be applied to the QtCompat object
-    decorators['windowTitleDecorator:QtWidgets.QWidget.windowTitle'] = \
+    decorators["windowTitleDecorator:QtWidgets.QWidget.windowTitle"] = \
         _testFunction

--- a/examples/QtSiteConfig/README.md
+++ b/examples/QtSiteConfig/README.md
@@ -118,9 +118,9 @@ def update_members_example(members, step):
     """
     if step == 'compatibility':
         members['PyQt4']["QFileDialog"] = {
-            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
-            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
-            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
         }
 
 def update_compatibility_decorators_example(binding, decorators):
@@ -149,10 +149,10 @@ def update_compatibility_decorators_example(binding, decorators):
             wrapper.__doc__ = some_function.__doc__
             wrapper.__name__ = some_function.__name__
             return wrapper
-        decorators["getOpenFileName:_QtWidgets.QFileDialog.getOpenFileName"] = \
+        decorators["getOpenFileName:QtWidgets.QFileDialog.getOpenFileName"] = \
             _standardizeQFileDialog
-        decorators["getOpenFileNames:_QtWidgets.QFileDialog.getOpenFileNames"] = \
+        decorators["getOpenFileNames:QtWidgets.QFileDialog.getOpenFileNames"] = \
             _standardizeQFileDialog
-        decorators["getSaveFileName:_QtWidgets.QFileDialog.getSaveFileName"] = \
+        decorators["getSaveFileName:QtWidgets.QFileDialog.getSaveFileName"] = \
             _standardizeQFileDialog
 ```

--- a/examples/QtSiteConfig/README.md
+++ b/examples/QtSiteConfig/README.md
@@ -28,9 +28,13 @@ $ python main.py
 
 If you need to  you can also add modules that are not in the standard Qt.py.
 
+#### QtSiteConfig.py: Adding non-standard modules
+
+This example shows how to add a module that is not included by default with Qt.py.
+
 ```python
 def update_members_example(members):
-    """An example of adding QJsonDocument to QtCore and the Qsci.
+    """An example of adding Qsci to Qt.py.
     
     Remove "_example" from the function name to use this example.
 
@@ -40,61 +44,115 @@ def update_members_example(members):
 
     """
 
-    # Include QJsonDocument module
-    members["QtCore"].append("QJsonDocument")
+    if step == 'common':
+        # Include Qsci module for scintilla lexer support.
+        members["Qsci"] = [
+            "QsciAPIs",
+            "QsciAbstractAPIs",
+            "QsciCommand",
+            "QsciCommandSet",
+            "QsciDocument",
+            "QsciLexer",
+            "QsciLexerAVS",
+            "QsciLexerBash",
+            "QsciLexerBatch",
+            "QsciLexerCMake",
+            "QsciLexerCPP",
+            "QsciLexerCSS",
+            "QsciLexerCSharp",
+            "QsciLexerCoffeeScript",
+            "QsciLexerCustom",
+            "QsciLexerD",
+            "QsciLexerDiff",
+            "QsciLexerFortran",
+            "QsciLexerFortran77",
+            "QsciLexerHTML",
+            "QsciLexerIDL",
+            "QsciLexerJSON",
+            "QsciLexerJava",
+            "QsciLexerJavaScript",
+            "QsciLexerLua",
+            "QsciLexerMakefile",
+            "QsciLexerMarkdown",
+            "QsciLexerMatlab",
+            "QsciLexerOctave",
+            "QsciLexerPO",
+            "QsciLexerPOV",
+            "QsciLexerPascal",
+            "QsciLexerPerl",
+            "QsciLexerPostScript",
+            "QsciLexerProperties",
+            "QsciLexerPython",
+            "QsciLexerRuby",
+            "QsciLexerSQL",
+            "QsciLexerSpice",
+            "QsciLexerTCL",
+            "QsciLexerTeX",
+            "QsciLexerVHDL",
+            "QsciLexerVerilog",
+            "QsciLexerXML",
+            "QsciLexerYAML",
+            "QsciMacro",
+            "QsciPrinter",
+            "QsciScintilla",
+            "QsciScintillaBase",
+            "QsciStyle",
+            "QsciStyledText",
+        ]
+```
 
-    # Include Qsci module for scintilla lexer support.
-    members["Qsci"] = [
-        "QsciAPIs",
-        "QsciAbstractAPIs",
-        "QsciCommand",
-        "QsciCommandSet",
-        "QsciDocument",
-        "QsciLexer",
-        "QsciLexerAVS",
-        "QsciLexerBash",
-        "QsciLexerBatch",
-        "QsciLexerCMake",
-        "QsciLexerCPP",
-        "QsciLexerCSS",
-        "QsciLexerCSharp",
-        "QsciLexerCoffeeScript",
-        "QsciLexerCustom",
-        "QsciLexerD",
-        "QsciLexerDiff",
-        "QsciLexerFortran",
-        "QsciLexerFortran77",
-        "QsciLexerHTML",
-        "QsciLexerIDL",
-        "QsciLexerJSON",
-        "QsciLexerJava",
-        "QsciLexerJavaScript",
-        "QsciLexerLua",
-        "QsciLexerMakefile",
-        "QsciLexerMarkdown",
-        "QsciLexerMatlab",
-        "QsciLexerOctave",
-        "QsciLexerPO",
-        "QsciLexerPOV",
-        "QsciLexerPascal",
-        "QsciLexerPerl",
-        "QsciLexerPostScript",
-        "QsciLexerProperties",
-        "QsciLexerPython",
-        "QsciLexerRuby",
-        "QsciLexerSQL",
-        "QsciLexerSpice",
-        "QsciLexerTCL",
-        "QsciLexerTeX",
-        "QsciLexerVHDL",
-        "QsciLexerVerilog",
-        "QsciLexerXML",
-        "QsciLexerYAML",
-        "QsciMacro",
-        "QsciPrinter",
-        "QsciScintilla",
-        "QsciScintillaBase",
-        "QsciStyle",
-        "QsciStyledText",
-    ]
+
+#### QtSiteConfig.py: Standardizing PyQt4 functionality
+
+This example reproduces functionality already in Qt.py but it provides a good example of what is necessary to create your QtCompat namespaces with custom function decorators to change how the source function runs.
+
+```python
+def update_members_example(members, step):
+    """This function is called by Qt.py to modify the modules it exposes.
+
+    Remove "_example" from the function name to use this example.
+
+    Arguments:
+        members (dict): The members considered by Qt.py
+        step (str): Used to identify what members will be used for.
+    """
+    if step == 'compatibility':
+        members['PyQt4']["QFileDialog"] = {
+            "getOpenFileName": "_QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "_QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "_QtWidgets.QFileDialog.getSaveFileName",
+        }
+
+def update_compatibility_decorators_example(binding, decorators):
+    """ This function is called by Qt.py to modify the decorators applied to
+    QtCompat namespace objects. Defining this method is optional.
+
+    Remove "_example" from the function name to use this example.
+
+    Arguments:
+        binding (str): The Qt binding being wrapped by Qt.py
+        decorators (dict): Maps specific decorator functions to
+            QtCompat namespace functions. See Qt._build_compatibility_members
+            for more info.
+    """
+    if binding == 'PyQt4':
+        # QFileDialog QtCompat decorator
+        def _standardizeQFileDialog(some_function):
+            """ decorator that makes PyQt4 return conform to other bindings
+            """
+            def wrapper(*args, **kwargs):
+                ret = some_function(*args, **kwargs)
+                # PyQt4 only returns the selected filename
+                # force the return to conform to all other bindings
+                return (ret, '')
+            # preserve docstring and name of original function
+            wrapper.__doc__ = some_function.__doc__
+            wrapper.__name__ = some_function.__name__
+            return wrapper
+        decorators["getOpenFileName:_QtWidgets.QFileDialog.getOpenFileName"] = \
+            _standardizeQFileDialog
+        decorators["getOpenFileNames:_QtWidgets.QFileDialog.getOpenFileNames"] = \
+            _standardizeQFileDialog
+        decorators["getSaveFileName:_QtWidgets.QFileDialog.getSaveFileName"] = \
+            _standardizeQFileDialog
 ```

--- a/examples/QtSiteConfig/README.md
+++ b/examples/QtSiteConfig/README.md
@@ -2,8 +2,6 @@
 
 This example illustrates how to make a QtSiteConfig module and how it affects Qt.py at run-time.
 
-<br>
-
 **Usage**
 
 ```bash
@@ -24,115 +22,125 @@ $ python main.py
 
 <br>
 
-**Advanced example**
+**Advanced examples**
 
-If you need to  you can also add modules that are not in the standard Qt.py.
+If you need to you can also add modules that are not in the standard Qt.py. All of these functions are optional in QtSiteConfig, so only implement the functions you need.
 
 #### QtSiteConfig.py: Adding non-standard modules
 
-This example shows how to add a module that is not included by default with Qt.py.
+By default Qt.py only exposes the "lowest common denominator" of all bindings. This example shows how to add the Qsci module that is not included by default with Qt.py.
 
 ```python
-def update_members_example(members):
+def update_members(members):
     """An example of adding Qsci to Qt.py.
-    
-    Remove "_example" from the function name to use this example.
 
     Arguments:
         members (dict): The default list of members in Qt.py.
             Update this dict with any modifications needed.
-
     """
 
-    if step == 'common':
-        # Include Qsci module for scintilla lexer support.
-        members["Qsci"] = [
-            "QsciAPIs",
-            "QsciAbstractAPIs",
-            "QsciCommand",
-            "QsciCommandSet",
-            "QsciDocument",
-            "QsciLexer",
-            "QsciLexerAVS",
-            "QsciLexerBash",
-            "QsciLexerBatch",
-            "QsciLexerCMake",
-            "QsciLexerCPP",
-            "QsciLexerCSS",
-            "QsciLexerCSharp",
-            "QsciLexerCoffeeScript",
-            "QsciLexerCustom",
-            "QsciLexerD",
-            "QsciLexerDiff",
-            "QsciLexerFortran",
-            "QsciLexerFortran77",
-            "QsciLexerHTML",
-            "QsciLexerIDL",
-            "QsciLexerJSON",
-            "QsciLexerJava",
-            "QsciLexerJavaScript",
-            "QsciLexerLua",
-            "QsciLexerMakefile",
-            "QsciLexerMarkdown",
-            "QsciLexerMatlab",
-            "QsciLexerOctave",
-            "QsciLexerPO",
-            "QsciLexerPOV",
-            "QsciLexerPascal",
-            "QsciLexerPerl",
-            "QsciLexerPostScript",
-            "QsciLexerProperties",
-            "QsciLexerPython",
-            "QsciLexerRuby",
-            "QsciLexerSQL",
-            "QsciLexerSpice",
-            "QsciLexerTCL",
-            "QsciLexerTeX",
-            "QsciLexerVHDL",
-            "QsciLexerVerilog",
-            "QsciLexerXML",
-            "QsciLexerYAML",
-            "QsciMacro",
-            "QsciPrinter",
-            "QsciScintilla",
-            "QsciScintillaBase",
-            "QsciStyle",
-            "QsciStyledText",
-        ]
+    # Include Qsci module for scintilla lexer support.
+    members["Qsci"] = [
+        "QsciAPIs",
+        "QsciAbstractAPIs",
+        "QsciCommand",
+        "QsciCommandSet",
+        "QsciDocument",
+        "QsciLexer",
+        "QsciLexerAVS",
+        "QsciLexerBash",
+        "QsciLexerBatch",
+        "QsciLexerCMake",
+        "QsciLexerCPP",
+        "QsciLexerCSS",
+        "QsciLexerCSharp",
+        "QsciLexerCoffeeScript",
+        "QsciLexerCustom",
+        "QsciLexerD",
+        "QsciLexerDiff",
+        "QsciLexerFortran",
+        "QsciLexerFortran77",
+        "QsciLexerHTML",
+        "QsciLexerIDL",
+        "QsciLexerJSON",
+        "QsciLexerJava",
+        "QsciLexerJavaScript",
+        "QsciLexerLua",
+        "QsciLexerMakefile",
+        "QsciLexerMarkdown",
+        "QsciLexerMatlab",
+        "QsciLexerOctave",
+        "QsciLexerPO",
+        "QsciLexerPOV",
+        "QsciLexerPascal",
+        "QsciLexerPerl",
+        "QsciLexerPostScript",
+        "QsciLexerProperties",
+        "QsciLexerPython",
+        "QsciLexerRuby",
+        "QsciLexerSQL",
+        "QsciLexerSpice",
+        "QsciLexerTCL",
+        "QsciLexerTeX",
+        "QsciLexerVHDL",
+        "QsciLexerVerilog",
+        "QsciLexerXML",
+        "QsciLexerYAML",
+        "QsciMacro",
+        "QsciPrinter",
+        "QsciScintilla",
+        "QsciScintillaBase",
+        "QsciStyle",
+        "QsciStyledText",
+    ]
 ```
 
 
-#### QtSiteConfig.py: Standardizing PyQt4 functionality
+#### QtSiteConfig.py: Standardizing the location of Qt classes
 
-This example reproduces functionality already in Qt.py but it provides a good example of what is necessary to create your QtCompat namespaces with custom function decorators to change how the source function runs.
+Some classes have been moved to new locations between bindings. Qt.py uses the namespace dictated by PySide2 and most members are already in place.
+This example reproduces functionality already in Qt.py but it provides a good example of how use this function.
 
 ```python
-def update_members_example(members, step):
-    """This function is called by Qt.py to modify the modules it exposes.
-
-    Remove "_example" from the function name to use this example.
+def update_misplaced_members(members):
+    """This optional function is called by Qt.py to standardize the location
+    and naming of exposed classes.
 
     Arguments:
         members (dict): The members considered by Qt.py
-        step (str): Used to identify what members will be used for.
     """
-    if step == 'compatibility':
-        members['PyQt4']["QFileDialog"] = {
-            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
-            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
-            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
-        }
+    # Standardize the the Property name
+    members["PySide2"]["QtCore.Property"] = "QtCore.Property"
+    members["PyQt5"]["QtCore.pyqtProperty"] = "QtCore.Property"
+    members["PySide"]["QtCore.Property"] = "QtCore.Property"
+    members["PyQt4"]["QtCore.pyqtProperty"] = "QtCore.Property"
+```
 
-def update_compatibility_decorators_example(binding, decorators):
+#### QtSiteConfig.py: Standardizing PyQt4's QFileDialog functionality
+
+This example reproduces functionality already in Qt.py but it provides a good example of what is necessary to create your QtCompat namespaces with custom method decorators to change how the source method runs.
+
+```python
+def update_compatibility_members(members):
+    """This function is called by Qt.py to modify the modules it exposes.
+
+    Arguments:
+        members (dict): The members considered by Qt.py
+    """
+    members['PyQt4']["QFileDialog"] = {
+        "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+        "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+        "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
+    }
+
+def update_compatibility_decorators(binding, decorators):
     """ This function is called by Qt.py to modify the decorators applied to
     QtCompat namespace objects. Defining this method is optional.
 
-    Remove "_example" from the function name to use this example.
-
     Arguments:
         binding (str): The Qt binding being wrapped by Qt.py
-        decorators (dict): Maps specific decorator functions to
-            QtCompat namespace functions. See Qt._build_compatibility_members
+        decorators (dict): Maps specific decorator methods to
+            QtCompat namespace methods. See Qt._build_compatibility_members
             for more info.
     """
     if binding == 'PyQt4':
@@ -142,17 +150,19 @@ def update_compatibility_decorators_example(binding, decorators):
             """
             def wrapper(*args, **kwargs):
                 ret = some_function(*args, **kwargs)
-                # PyQt4 only returns the selected filename
-                # force the return to conform to all other bindings
+                # PyQt4 only returns the selected filename, force it to a
+                # standard return of the selected filename, and a empty string
+                # for the selected filter
                 return (ret, '')
-            # preserve docstring and name of original function
+            # preserve docstring and name of original method
             wrapper.__doc__ = some_function.__doc__
             wrapper.__name__ = some_function.__name__
             return wrapper
-        decorators["getOpenFileName:QtWidgets.QFileDialog.getOpenFileName"] = \
+
+        decorators.setdefault("QFileDialog",{})["getOpenFileName"] = \
             _standardizeQFileDialog
-        decorators["getOpenFileNames:QtWidgets.QFileDialog.getOpenFileNames"] = \
+        decorators.setdefault("QFileDialog",{})["getOpenFileNames"] = \
             _standardizeQFileDialog
-        decorators["getSaveFileName:QtWidgets.QFileDialog.getSaveFileName"] = \
+        decorators.setdefault("QFileDialog",{})["getSaveFileName"] = \
             _standardizeQFileDialog
 ```

--- a/examples/QtSiteConfig/main.py
+++ b/examples/QtSiteConfig/main.py
@@ -1,11 +1,11 @@
-"""Example of QtSideConfig module used to modify exposed members of Qt.py"""
+"""Example of QtSiteConfig module used to modify exposed members of Qt.py"""
 
 import os
 import sys
 
 
 def test():
-    """QtCore is taken out of Qt.py via QSiteConfig.py"""
+    """QtCore is taken out of Qt.py via QtSiteConfig.py"""
 
     # Expose this directory, and therefore QtSiteConfig, to Python
     sys.path.insert(0, os.path.dirname(__file__))
@@ -14,7 +14,7 @@ def test():
         from Qt import QtCore
 
     except ImportError:
-        print("Qt.QtCore was successfully removed by QSideConfig.py")
+        print("Qt.QtCore was successfully removed by QtSiteConfig.py")
 
     else:
         raise ImportError(
@@ -34,17 +34,24 @@ def test():
     title = "Test Widget"
     from Qt import QtWidgets, QtCompat
     app = QtWidgets.QApplication(sys.argv)
-    win = QtWidgets.QWidget()
-    win.setWindowTitle(title)
+    wid = QtWidgets.QWidget()
+    wid.setWindowTitle(title)
 
     # Verify that our simple remapping of QWidget.windowTitle works
-    assert QtCompat.QWidget.windowTitleTest(win) == title, \
+    assert QtCompat.QWidget.windowTitleTest(wid) == title, \
         "Non-decorated function was added to QtCompat.QWidget"
     # Verify that our decorated remapping of QWidget.windowTitle works
     check = "Test: {}".format(title)
-    assert QtCompat.QWidget.windowTitleDecorator(win) == check, \
-        "Decorated function was added to QtCompat.QWidget"
+    assert QtCompat.QWidget.windowTitleDecorator(wid) == check, \
+        "Decorated method was not added to QtCompat.QWidget"
 
+    # Verify that our decorated remapping of QMainWindow.windowTitle is
+    # different than the QWidget version.
+    win = QtWidgets.QMainWindow()
+    win.setWindowTitle(title)
+    check = "QMainWindow Test: {}".format(title)
+    assert QtCompat.QMainWindow.windowTitleDecorator(win) == check, \
+        "Decorated method was added to QtCompat.QMainWindow"
     # Suppress "app" imported but unused warning
     app
 

--- a/examples/QtSiteConfig/main.py
+++ b/examples/QtSiteConfig/main.py
@@ -25,6 +25,24 @@ def test():
         # Suppress 'Qt.QtCore' imported but unused warning
         QtCore
 
+    # Test _compatibility_members is applied correctly
+    title = 'Test Widget'
+    from Qt import QtWidgets, QtCompat
+    app = QtWidgets.QApplication(sys.argv)
+    win = QtWidgets.QWidget()
+    win.setWindowTitle(title)
+
+    # Verify that our simple remapping of QWidget.windowTitle works
+    assert QtCompat.QWidget.windowTitleTest(win) == title, \
+        "Non-decorated function was added to QtCompat.QWidget"
+    # Verify that our decorated remapping of QWidget.windowTitle works
+    check = 'Test: {}'.format(title)
+    assert QtCompat.QWidget.windowTitleDecorator(win) == check, \
+        "Decorated function was added to QtCompat.QWidget"
+
+    # Suppress 'app' imported but unused warning
+    app
+
 
 if __name__ == '__main__':
     test()

--- a/examples/QtSiteConfig/main.py
+++ b/examples/QtSiteConfig/main.py
@@ -22,11 +22,16 @@ def test():
             "applied correctly."
         )
 
-        # Suppress 'Qt.QtCore' imported but unused warning
+        # Suppress "Qt.QtCore" imported but unused warning
         QtCore
 
+    # Test _misplaced_members is applied correctly
+    from Qt import QtGui
+    assert QtGui.QColorTest == QtGui.QColor, \
+        "QtGui.QColor was not mapped to QtGui.QColorTest"
+
     # Test _compatibility_members is applied correctly
-    title = 'Test Widget'
+    title = "Test Widget"
     from Qt import QtWidgets, QtCompat
     app = QtWidgets.QApplication(sys.argv)
     win = QtWidgets.QWidget()
@@ -36,13 +41,13 @@ def test():
     assert QtCompat.QWidget.windowTitleTest(win) == title, \
         "Non-decorated function was added to QtCompat.QWidget"
     # Verify that our decorated remapping of QWidget.windowTitle works
-    check = 'Test: {}'.format(title)
+    check = "Test: {}".format(title)
     assert QtCompat.QWidget.windowTitleDecorator(win) == check, \
         "Decorated function was added to QtCompat.QWidget"
 
-    # Suppress 'app' imported but unused warning
+    # Suppress "app" imported but unused warning
     app
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test()

--- a/tests.py
+++ b/tests.py
@@ -420,6 +420,23 @@ def test_binding_states():
     assert Qt.IsPyQt4 == binding("PyQt4")
 
 
+def test_qtcompat_base_class():
+    """Tests to ensure the QtCompat namespace object works as expected"""
+    import sys
+    import Qt
+    from Qt import QtWidgets
+    from Qt import QtCompat
+    app = QtWidgets.QApplication(sys.argv)
+    # suppress `local variable 'app' is assigned to but never used`
+    app
+    header = QtWidgets.QHeaderView(Qt.QtCore.Qt.Horizontal)
+
+    # Spot check compatibility functions
+    QtCompat.QHeaderView.setSectionsMovable(header, False)
+    assert QtCompat.QHeaderView.sectionsMovable(header) is False
+    QtCompat.QHeaderView.setSectionsMovable(header, True)
+    assert QtCompat.QHeaderView.sectionsMovable(header) is True
+
 def test_cli():
     """Qt.py is available from the command-line"""
     env = os.environ.copy()


### PR DESCRIPTION
This pull request address the problems raised in #225 by adding backwards compatibility.

I've updated the the call to `QtSiteConfig.update_members` to attempt to call the new two argument structure, and if that fails, it logs a message and calls `update_members` passing the single argument.