### PR TITLE
Work around pyside2uic bug

### DIFF
--- a/Dockerfile.vfxplatform2017
+++ b/Dockerfile.vfxplatform2017
@@ -624,9 +624,15 @@ RUN \
     cd pyside-setup && \
     git checkout ${PYSIDE2_GIT_COMMIT} && \
     git submodule update --init --recursive && \
+
     # Fix bug in order to build PySide2.QtUiTools: https://bugreports.qt.io/browse/PYSIDE-552
     # sed -i.bak $'s/if(Qt5Designer_FOUND)/find_package(Qt5Designer)\\\nif(Qt5Designer_FOUND)/g' sources/pyside2/CMakeLists.txt && \
     # cat sources/pyside2/CMakeLists.txt && \
+
+    # Fix bug https://bugreports.qt.io/browse/PYSIDE-357
+    sed -i -e "s~\b\(packages\b.*\)],~\1, 'pyside2uic.Compiler', 'pyside2uic.port_v' + str(sys.version_info[0])],~" setup.py && \
+    # cat setup.py && \
+
     python${PYTHON27_VER} setup.py \
         # bdist_wheel \
         install \
@@ -644,9 +650,15 @@ RUN \
     cd pyside-setup && \
     git checkout ${PYSIDE2_GIT_COMMIT} && \
     git submodule update --init --recursive && \
-    # # Fix bug in order to build PySide2.QtUiTools: https://bugreports.qt.io/browse/PYSIDE-552
+
+    # Fix bug in order to build PySide2.QtUiTools: https://bugreports.qt.io/browse/PYSIDE-552
     # sed -i.bak $'s/if(Qt5Designer_FOUND)/find_package(Qt5Designer)\\\nif(Qt5Designer_FOUND)/g' sources/pyside2/CMakeLists.txt && \
-    # # cat sources/pyside2/CMakeLists.txt && \
+    # cat sources/pyside2/CMakeLists.txt && \
+
+    # Fix bug https://bugreports.qt.io/browse/PYSIDE-357
+    sed -i -e "s~\b\(packages\b.*\)],~\1, 'pyside2uic.Compiler', 'pyside2uic.port_v' + str(sys.version_info[0])],~" setup.py && \
+    # cat setup.py && \
+
     python${PYTHON34_VER} setup.py \
         # bdist_wheel \
         install \
@@ -664,9 +676,15 @@ RUN \
     cd pyside-setup && \
     git checkout ${PYSIDE2_GIT_COMMIT} && \
     git submodule update --init --recursive && \
-    # # Fix bug in order to build PySide2.QtUiTools: https://bugreports.qt.io/browse/PYSIDE-552
+
+    # Fix bug in order to build PySide2.QtUiTools: https://bugreports.qt.io/browse/PYSIDE-552
     # sed -i.bak $'s/if(Qt5Designer_FOUND)/find_package(Qt5Designer)\\\nif(Qt5Designer_FOUND)/g' sources/pyside2/CMakeLists.txt && \
-    # # cat sources/pyside2/CMakeLists.txt && \
+    # cat sources/pyside2/CMakeLists.txt && \
+
+    # Fix bug https://bugreports.qt.io/browse/PYSIDE-357
+    sed -i -e "s~\b\(packages\b.*\)],~\1, 'pyside2uic.Compiler', 'pyside2uic.port_v' + str(sys.version_info[0])],~" setup.py && \
+    # cat setup.py && \
+
     python${PYTHON35_VER} setup.py \
         # bdist_wheel \
         install \


### PR DESCRIPTION
Adds `sed` command to Dockerfile:

```bash
sed -i -e "s~\b\(packages\b.*\)],~\1, 'pyside2uic.Compiler', 'pyside2uic.port_v' + str(sys.version_info[0])],~" setup.py
```

This makes sure that `setup.py` copies the necessary submodules of `pyside2uic` into the wheel.

Now, `pyside2-uic` exists and works in `/usr/local/pythonX.X/bin/pyside2-uic`. No symlinks were made to make it available as e.g. `pyside2-uic2.7`. If we need that, I can add it.

Dockerfile was re-built and pushed.