### PR TITLE
--convert option: raise an error if the input ui file defined signals

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -1295,6 +1295,11 @@ def _convert(lines):
         line = line.replace("from PySide2 import", "from Qt import QtCompat,")
         line = line.replace("QtWidgets.QApplication.translate",
                             "QtCompat.translate")
+        if "QtCore.SIGNAL" in line:
+            raise NotImplementedError("QtCore.SIGNAL is missing from PyQt5 "
+                                      "and so Qt.py does not support it: you "
+                                      "should avoid defining signals inside "
+                                      "your ui files.")
         return line
 
     parsed = list()


### PR DESCRIPTION
* Currently it does not work: I have to define my signal in my python
code instead of my ui file.
* I did not find a good solution... So for now I think it's better to
warn the user about this unsupported feature than silently tell nothing.
Do you have a solution to support this feature? :)