### PR TITLE
Update README with conda info, include LICENSE in tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include LICENSE

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/mottosso/Qt.py.svg?branch=master)](https://travis-ci.org/mottosso/Qt.py) [![PyPI version](https://badge.fury.io/py/Qt.py.svg)](https://pypi.python.org/pypi/Qt.py)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/qt.py/badges/version.svg)](https://anaconda.org/conda-forge/qt.py)
 
 ### Qt.py
 
@@ -75,10 +76,15 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for more details.
 
 ### Install
 
-Qt.py is a single file and can either be [copy/pasted](https://raw.githubusercontent.com/mottosso/Qt.py/master/Qt.py) into your project, [downloaded](https://github.com/mottosso/Qt.py/archive/master.zip) as-is, cloned as-is or installed via PyPI.
+Qt.py is a single file and can either be [copy/pasted](https://raw.githubusercontent.com/mottosso/Qt.py/master/Qt.py) into your project, [downloaded](https://github.com/mottosso/Qt.py/archive/master.zip) as-is, cloned as-is, or installed via PyPI or Anaconda Cloud.
 
 ```bash
+# PyPi
 $ pip install Qt.py
+
+# Conda
+$ conda config --add channels conda-forge
+$ conda install qt.py
 ```
 
 - Pro tip: **Never use the latest commit for production**. Instead, use [the latest release](https://github.com/mottosso/Qt.py/releases). That way, when you read bug reports or make one for yourself you will be able to match a version with the problem without which you will not know which fixes apply to you nor would we be able to help you. Installing via pip as above ensures you are provided the latest *stable* release. Unstable releases are suffixed with a `.b`, e.g. `1.1.0.b3`.

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     url="https://github.com/mottosso/Qt",
     license="MIT",
     zip_safe=False,
+    data_files=['LICENSE'],
     py_modules=["Qt"],
     classifiers=classifiers
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     url="https://github.com/mottosso/Qt",
     license="MIT",
     zip_safe=False,
-    data_files=['LICENSE'],
+    data_files=["LICENSE"],
     py_modules=["Qt"],
     classifiers=classifiers
 )


### PR DESCRIPTION
Fixes #202 

Qt.py was today added to conda/Anaconda Cloud/conda-forge and its feedstock lives [here](https://github.com/conda-forge/qt.py-feedstock/blob/master/README.md).

I added the Anaconda Cloud badge to the README and extended the install instructions with a conda example.

What's particularly cool about this, is that PySide2 can be – as of yesterday – _also_ installed with conda:
This makes me very happy:

```bash
$ conda config --add channels conda-forge
$ conda install qt.py pyside2
```

We should make our `LICENSE` be included in the [Qt.py tarball](https://pypi.org/project/Qt.py/#files) instead of keeping a copy of it in [qt.py-feedstock](https://github.com/conda-forge/qt.py-feedstock). I've added `MANIFEST.in` to this PR, which is [supposed to handle this](https://docs.python.org/3/distutils/sourcedist.html#specifying-the-files-to-distribute) but I'm not sure how to test this. We need to trigger a PyPi release (through Travis) to know for sure?