### PR TITLE
Add QStyleOptionViewItem

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -666,7 +666,7 @@ _misplaced_members = {
         "QtCore.QItemSelection": "QtCore.QItemSelection",
         "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
         "QtCore.QItemSelectionRange": "QtCore.QItemSelectionRange",
-        "QtWidgets.QStyleOptionViewItem": "QtCompat.QStyleOptionViewItem",
+        "QtWidgets.QStyleOptionViewItem": "QtCompat.QStyleOptionViewItemV4",
     },
     "PyQt5": {
         "QtCore.pyqtProperty": "QtCore.Property",
@@ -678,7 +678,7 @@ _misplaced_members = {
         "QtCore.QItemSelection": "QtCore.QItemSelection",
         "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
         "QtCore.QItemSelectionRange": "QtCore.QItemSelectionRange",
-        "QtWidgets.QStyleOptionViewItem": "QtCompat.QStyleOptionViewItem",
+        "QtWidgets.QStyleOptionViewItem": "QtCompat.QStyleOptionViewItemV4",
     },
     "PySide": {
         "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
@@ -690,7 +690,7 @@ _misplaced_members = {
         "QtCore.Signal": "QtCore.Signal",
         "QtCore.Slot": "QtCore.Slot",
         "QtGui.QItemSelectionRange": "QtCore.QItemSelectionRange",
-        "QtGui.QStyleOptionViewItemV4": "QtCompat.QStyleOptionViewItem",
+        "QtGui.QStyleOptionViewItemV4": "QtCompat.QStyleOptionViewItemV4",
 
     },
     "PyQt4": {
@@ -703,7 +703,7 @@ _misplaced_members = {
         "QtCore.pyqtSignal": "QtCore.Signal",
         "QtCore.pyqtSlot": "QtCore.Slot",
         "QtGui.QItemSelectionRange": "QtCore.QItemSelectionRange",
-        "QtGui.QStyleOptionViewItemV4": "QtCompat.QStyleOptionViewItem",
+        "QtGui.QStyleOptionViewItemV4": "QtCompat.QStyleOptionViewItemV4",
     }
 }
 

--- a/Qt.py
+++ b/Qt.py
@@ -655,6 +655,7 @@ These members from the original submodule are misplaced relative PySide2
 
 """
 _misplaced_members = {
+    #                      FROM ---> TO
     "PySide2": {
         "QtGui.QStringListModel": "QtCore.QStringListModel",
         "QtCore.Property": "QtCore.Property",

--- a/Qt.py
+++ b/Qt.py
@@ -665,6 +665,7 @@ _misplaced_members = {
         "QtCore.QItemSelection": "QtCore.QItemSelection",
         "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
         "QtCore.QItemSelectionRange": "QtCore.QItemSelectionRange",
+        "QtWidgets.QStyleOptionViewItem": "QtCompat.QStyleOptionViewItem",
     },
     "PyQt5": {
         "QtCore.pyqtProperty": "QtCore.Property",
@@ -676,6 +677,7 @@ _misplaced_members = {
         "QtCore.QItemSelection": "QtCore.QItemSelection",
         "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
         "QtCore.QItemSelectionRange": "QtCore.QItemSelectionRange",
+        "QtWidgets.QStyleOptionViewItem": "QtCompat.QStyleOptionViewItem",
     },
     "PySide": {
         "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
@@ -687,6 +689,7 @@ _misplaced_members = {
         "QtCore.Signal": "QtCore.Signal",
         "QtCore.Slot": "QtCore.Slot",
         "QtGui.QItemSelectionRange": "QtCore.QItemSelectionRange",
+        "QtGui.QStyleOptionViewItemV4": "QtCompat.QStyleOptionViewItem",
 
     },
     "PyQt4": {
@@ -699,6 +702,7 @@ _misplaced_members = {
         "QtCore.pyqtSignal": "QtCore.Signal",
         "QtCore.pyqtSlot": "QtCore.Slot",
         "QtGui.QItemSelectionRange": "QtCore.QItemSelectionRange",
+        "QtGui.QStyleOptionViewItemV4": "QtCompat.QStyleOptionViewItem",
     }
 }
 


### PR DESCRIPTION
This adds `QStyleOptionViewItem` to `QtCompat`.

```python
from Qt import QtCompat
Qt.QStyleOptionViewItem
```

Under PyQt4 and PySide, this member refers to `QtGui.QStyleOptionViewItemV4`, under PyQt5 and PySide2 it refers to `QtWidgets.QStyleOptionViewItem` (note the missing `V4`).

- See here for details: https://doc.qt.io/qt-5/qstyleoptionviewitem-obsolete.html

This PR replaces https://github.com/mottosso/Qt.py/pull/257