### PR TITLE
Bump version to 1.1.0.b8

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -43,7 +43,7 @@ import types
 import shutil
 
 
-__version__ = "1.1.0.b7"
+__version__ = "1.1.0.b8"
 
 # Enable support for `from Qt import *`
 __all__ = []


### PR DESCRIPTION
Bumping because merge of #234 where [new members were added](https://github.com/mottosso/Qt.py/pull/234/files#diff-cd1d7c0a982bce680146d5b248151256).

This feels like a 1.1.0 release candidate to me! 😄 