### PR TITLE
Testing with CY2018 Update 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,24 @@
 matrix:
   include:
 
+  # VFX Platform 2018-update1
+  - os: linux
+    env:
+    - VFXPLATFORM=2018-update1
+    - PYTHON=2.7
+  - os: linux
+    env:
+    - VFXPLATFORM=2018-update1
+    - PYTHON=3.4
+  - os: linux
+    env:
+    - VFXPLATFORM=2018-update1
+    - PYTHON=3.5
+  - os: linux
+    env:
+    - VFXPLATFORM=2018-update1
+    - PYTHON=3.6
+
   # VFX Platform 2018
   - os: linux
     env:

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -95,6 +95,7 @@ You can then run `python2.7`, `python3.4`, `python3.5`, `python3.6` and so on (d
 | Qt5 | 2016-06-16 | [commit](http://code.qt.io/cgit/qt/qt5.git/commit/?h=5.6&id=4566f0ac50e5ea143943c1251028fb01c70289ce) |
 | Adsk Qt5 `qtbase` | 2017-06-07 | [commit](https://github.com/autodesk-forks/qtbase/commit/c4e51d0162f7619c83e25e623ecd3bc549932040) |
 | Adsk Qt5 `qtx11extras` | 2017-02-24 | [commit](https://github.com/autodesk-forks/qtx11extras/commit/c6c59d5d902db8be3661cab929be85a38fda0faa) |
+| Adsk Qt5 `qtdeclarative` | 2017-05-09 | [commit](https://github.com/autodesk-forks/qtdeclarative/commit/b14cd49f891327d8fa5f5607eb19288ca137c5e2) |
 | Qt5 Creator | 2017-08-09 | [commit](http://code.qt.io/cgit/qt-creator/qt-creator.git/commit/?h=4.3&id=a094841bdda5461ebeaeab4620dde8222fa8312d) |
 | Qt4 | 2015-10-23 | [commit](http://code.qt.io/cgit/qt/qt.git/commit/?id=0a2f2382541424726168804be2c90b91381608c6) |
 | cmake | 2017-07-18 | [v3.9.0](https://cmake.org/files/) |

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -99,7 +99,7 @@ You can then run `python2.7`, `python3.4`, `python3.5`, `python3.6` and so on (d
 | Qt4 | 2015-10-23 | [commit](http://code.qt.io/cgit/qt/qt.git/commit/?id=0a2f2382541424726168804be2c90b91381608c6) |
 | cmake | 2017-07-18 | [v3.9.0](https://cmake.org/files/) |
 | glibc | 2012 (installed via yum) | 2.17 |
-| gcc | 2015 (installed via devtoolset-4) | [v5.3.1] |
+| gcc | 2016-12-...? (installed via devtoolset-6) | [v6.3.1] |
 
 <br>
 <br>

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -55,11 +55,16 @@ Other noteworthy things:
 <br>
 <br>
 
+
 **Image tagging**
 
-A new image should be tagged like `repo/qt.py:YYYY`. For CY2017, this translates into `fredrikaverpil/qt.py:2017`.
+A new image should be tagged like `repo/qt.py:YYYY`. For CY2017, this translates into `fredrikaverpil/qt.py:2018-update1`.
 
-If there happens to be an update inbetween VFX Platform specifications, a revision version number could be added: `repo/qt.py:YYYY-update1`.
+If there happens to be an update between VFX Platform specifications, a revision version number could be added: `repo/qt.py:YYYY-update1`.
+
+Build command example:
+
+    docker build . -t fredrikaverpil/qt.py:2018-update1 -f Dockerfile.vfxplatform2018-update1
 
 <br>
 <br>
@@ -70,7 +75,7 @@ If there happens to be an update inbetween VFX Platform specifications, a revisi
 For debugging reasons, you can enter the container like this:
 
 ```bash
-docker run --rm --interactive --tty --entrypoint=bash fredrikaverpil/qt.py:2017
+docker run --rm --interactive --tty --entrypoint=bash fredrikaverpil/qt.py:2018-update1
 ```
 
 You can then run `python2.7`, `python3.4`, `python3.5`, `python3.6` and so on (depending on which Python versions were built).
@@ -78,8 +83,7 @@ You can then run `python2.7`, `python3.4`, `python3.5`, `python3.6` and so on (d
 <br>
 <br>
 
-
-**Dockerfile.vfxplatform2018**
+**Dockerfile.vfxplatform2018-update1**
 
 | Software | Date | Details |
 | -------- | ---- | --------------- |
@@ -101,6 +105,32 @@ You can then run `python2.7`, `python3.4`, `python3.5`, `python3.6` and so on (d
 | cmake | 2017-07-18 | [v3.9.0](https://cmake.org/files/) |
 | glibc | 2012 (installed via yum) | 2.17 |
 | gcc | 2016-12-...? (installed via devtoolset-6) | [v6.3.1] |
+
+<br>
+<br>
+
+
+**Dockerfile.vfxplatform2018**
+
+| Software | Date | Details |
+| -------- | ---- | --------------- |
+| PySide2 | 2017-08-24 | [commit](http://code.qt.io/cgit/pyside/pyside-setup.git/commit/?h=5.6&id=117e0ff91275b4bc06dd5383f19e7028c5ef6ff8) |
+| PySide | 2015-10-15 | [commit](https://github.com/pyside/pyside-setup/commit/7860bda363438e96fa9e810def0858635a9766cc) |
+| SIP | 2016-07-25 | [v4.18.1](https://sourceforge.net/projects/pyqt/files/sip/) |
+| PyQt5 | 2016-04-25 | [v5.6](https://sourceforge.net/projects/pyqt/files/PyQt5/) |
+| PyQt4 | 2015-08-01 | [v4.11.4](https://sourceforge.net/projects/pyqt/files/PyQt4/) |
+| Python 2.7 | 2015-12-05 | [v2.7.11](https://www.python.org/downloads/source/) |
+| Python 3.4 | 2017-08-09 | [v3.4.7](https://www.python.org/downloads/source/) |
+| Python 3.5 | 2017-08-08 | [v3.5.4](https://www.python.org/downloads/source/) |
+| Python 3.6 | 2017-07-17 | [v3.6.2](https://www.python.org/downloads/source/) |
+| Qt5 | 2016-06-16 | [commit](http://code.qt.io/cgit/qt/qt5.git/commit/?h=5.6&id=4566f0ac50e5ea143943c1251028fb01c70289ce) |
+| Adsk Qt5 `qtbase` | 2017-06-07 | [commit](https://github.com/autodesk-forks/qtbase/commit/c4e51d0162f7619c83e25e623ecd3bc549932040) |
+| Adsk Qt5 `qtx11extras` | 2017-02-24 | [commit](https://github.com/autodesk-forks/qtx11extras/commit/c6c59d5d902db8be3661cab929be85a38fda0faa) |
+| Qt5 Creator | 2017-08-09 | [commit](http://code.qt.io/cgit/qt-creator/qt-creator.git/commit/?h=4.3&id=a094841bdda5461ebeaeab4620dde8222fa8312d) |
+| Qt4 | 2015-10-23 | [commit](http://code.qt.io/cgit/qt/qt.git/commit/?id=0a2f2382541424726168804be2c90b91381608c6) |
+| cmake | 2017-07-18 | [v3.9.0](https://cmake.org/files/) |
+| glibc | 2012 (installed via yum) | 2.17 |
+| gcc | 2015 (installed via devtoolset-4) | [v5.3.1] |
 
 <br>
 <br>

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -58,7 +58,7 @@ Other noteworthy things:
 
 **Image tagging**
 
-A new image should be tagged like `repo/qt.py:YYYY`. For CY2017, this translates into `fredrikaverpil/qt.py:2018-update1`.
+A new image should be tagged like `repo/qt.py:YYYY`. For CY2018, this translates into `fredrikaverpil/qt.py:2018-update1`.
 
 If there happens to be an update between VFX Platform specifications, a revision version number could be added: `repo/qt.py:YYYY-update1`.
 

--- a/Dockerfile.vfxplatform2018
+++ b/Dockerfile.vfxplatform2018
@@ -162,10 +162,12 @@ RUN \
 # Qt5: http://code.qt.io/cgit/qt/qt5.git/commit/?h=5.6&id=4566f0ac50e5ea143943c1251028fb01c70289ce
 # Adsk qtbase: https://github.com/autodesk-forks/qtbase/commit/c4e51d0162f7619c83e25e623ecd3bc549932040
 # Adsk qtx11extras: https://github.com/autodesk-forks/qtx11extras/commit/c6c59d5d902db8be3661cab929be85a38fda0faa
+# Adsk qtdeclarative: https://github.com/autodesk-forks/qtdeclarative/commit/b14cd49f891327d8fa5f5607eb19288ca137c5e2
 ENV QT5_GIT_BRANCH=5.6.1
 ENV QT5_GIT_COMMIT=4566f0ac50e5ea143943c1251028fb01c70289ce
 ENV ADSK_QTBASE_GIT_COMMIT=c4e51d0162f7619c83e25e623ecd3bc549932040
 ENV ADSK_QTX11EXTRAS_GIT_COMMIT=c6c59d5d902db8be3661cab929be85a38fda0faa
+ENV ADSK_QTDECLARATIVE_GIT_COMMIT=b14cd49f891327d8fa5f5607eb19288ca137c5e2
 
 RUN \
     git clone --recursive --jobs ${BUILD_THREADS} --branch ${QT5_GIT_BRANCH} https://code.qt.io/qt/qt5.git && \
@@ -182,15 +184,20 @@ RUN \
     mkdir -p /workdir/adsk && \
     git clone --recursive --branch adsk-contrib/vfx/${QT5_GIT_BRANCH} https://github.com/autodesk-forks/qtbase.git /workdir/adsk/qtbase && \
     git clone --recursive --branch adsk-contrib/vfx/${QT5_GIT_BRANCH} https://github.com/autodesk-forks/qtx11extras.git /workdir/adsk/qtx11extras && \
+    git clone --recursive --branch adsk-contrib/vfx/${QT5_GIT_BRANCH} https://github.com/autodesk-forks/qtdeclarative.git /workdir/adsk/qtdeclarative && \
     # Revert to commit SHA for qtbase
     cd /workdir/adsk/qtbase && \
     git checkout ${ADSK_QTBASE_GIT_COMMIT} && \
     # Revert to commit SHA for qtx11extras
     cd /workdir/adsk/qtx11extras && \
     git checkout ${ADSK_QTX11EXTRAS_GIT_COMMIT} && \
+    # Revert to commit SHA for qtdeclarative
+    cd /workdir/adsk/qtdeclarative && \
+    git checkout ${ADSK_QTDECLARATIVE_GIT_COMMIT} && \
     # Move Autodesk sources into qt5
     mv /workdir/adsk/qtbase /workdir/qt5 && \
     mv /workdir/adsk/qtx11extras /workdir/qt5 && \
+    mv /workdir/adsk/qtdeclarative /workdir/qt5 && \
     # Build
     cd /workdir/qt5 && \
     # ./configure -help && \

--- a/Dockerfile.vfxplatform2018
+++ b/Dockerfile.vfxplatform2018
@@ -7,8 +7,8 @@ RUN yum install deltarpm -y && \
         # cmake3 requirements
             epel-release && \
     yum install -y \
-        # gcc 5.3.1 (via Devtools which is equivalent of RedHat DTS)
-            devtoolset-4-gcc*-5.3.1 \
+        # gcc 6.3.1 (via Devtools which is equivalent of RedHat DTS)
+            devtoolset-6-gcc*-6.3.1 \
         # glibc 2.17
             glibc-*-2.17 \
         # Qt5 requirements
@@ -89,11 +89,11 @@ ENV BUILD_THREADS=17
 WORKDIR /workdir
 
 
-# Activate devtoolset-4 gcc 5.3.1
-# RUN scl enable devtoolset-4 bash
-ENV PATH="/opt/rh/devtoolset-4/root/usr/bin:${PATH}"
-ENV CC=/opt/rh/devtoolset-4/root/usr/bin/gcc
-ENV CXX=/opt/rh/devtoolset-4/root/usr/bin/g++
+# Activate devtoolset-6 gcc 6.3.1
+# RUN scl enable devtoolset-6 bash
+ENV PATH="/opt/rh/devtoolset-6/root/usr/bin:${PATH}"
+ENV CC=/opt/rh/devtoolset-6/root/usr/bin/gcc
+ENV CXX=/opt/rh/devtoolset-6/root/usr/bin/g++
 
 # # Check gcc version
 # RUN gcc --version

--- a/Dockerfile.vfxplatform2018-update1
+++ b/Dockerfile.vfxplatform2018-update1
@@ -7,8 +7,8 @@ RUN yum install deltarpm -y && \
         # cmake3 requirements
             epel-release && \
     yum install -y \
-        # gcc 5.3.1 (via Devtools which is equivalent of RedHat DTS)
-            devtoolset-4-gcc*-5.3.1 \
+        # gcc 6.3.1 (via Devtools which is equivalent of RedHat DTS)
+            devtoolset-6-gcc*-6.3.1 \
         # glibc 2.17
             glibc-*-2.17 \
         # Qt5 requirements
@@ -89,11 +89,11 @@ ENV BUILD_THREADS=17
 WORKDIR /workdir
 
 
-# Activate devtoolset-4 gcc 5.3.1
-# RUN scl enable devtoolset-4 bash
-ENV PATH="/opt/rh/devtoolset-4/root/usr/bin:${PATH}"
-ENV CC=/opt/rh/devtoolset-4/root/usr/bin/gcc
-ENV CXX=/opt/rh/devtoolset-4/root/usr/bin/g++
+# Activate devtoolset-6 gcc 6.3.1
+# RUN scl enable devtoolset-6 bash
+ENV PATH="/opt/rh/devtoolset-6/root/usr/bin:${PATH}"
+ENV CC=/opt/rh/devtoolset-6/root/usr/bin/gcc
+ENV CXX=/opt/rh/devtoolset-6/root/usr/bin/g++
 
 # # Check gcc version
 # RUN gcc --version
@@ -145,10 +145,14 @@ RUN \
         -opensource \
         -confirm-license \
         -nomake examples \
-        -nomake tests && \
-    make -j${BUILD_THREADS} && \
+        -nomake tests
+RUN \
+    cd qt && \
+    gmake -j${BUILD_THREADS}
     # Install
-    make install && \
+RUN \
+    cd qt && \
+    gmake install && \
     # Clean up
     rm -rf /workdir/*
 
@@ -162,10 +166,12 @@ RUN \
 # Qt5: http://code.qt.io/cgit/qt/qt5.git/commit/?h=5.6&id=4566f0ac50e5ea143943c1251028fb01c70289ce
 # Adsk qtbase: https://github.com/autodesk-forks/qtbase/commit/c4e51d0162f7619c83e25e623ecd3bc549932040
 # Adsk qtx11extras: https://github.com/autodesk-forks/qtx11extras/commit/c6c59d5d902db8be3661cab929be85a38fda0faa
+# Adsk qtdeclarative: https://github.com/autodesk-forks/qtdeclarative/commit/b14cd49f891327d8fa5f5607eb19288ca137c5e2
 ENV QT5_GIT_BRANCH=5.6.1
 ENV QT5_GIT_COMMIT=4566f0ac50e5ea143943c1251028fb01c70289ce
 ENV ADSK_QTBASE_GIT_COMMIT=c4e51d0162f7619c83e25e623ecd3bc549932040
 ENV ADSK_QTX11EXTRAS_GIT_COMMIT=c6c59d5d902db8be3661cab929be85a38fda0faa
+ENV ADSK_QTDECLARATIVE_GIT_COMMIT=b14cd49f891327d8fa5f5607eb19288ca137c5e2
 
 RUN \
     git clone --recursive --jobs ${BUILD_THREADS} --branch ${QT5_GIT_BRANCH} https://code.qt.io/qt/qt5.git && \
@@ -182,15 +188,20 @@ RUN \
     mkdir -p /workdir/adsk && \
     git clone --recursive --branch adsk-contrib/vfx/${QT5_GIT_BRANCH} https://github.com/autodesk-forks/qtbase.git /workdir/adsk/qtbase && \
     git clone --recursive --branch adsk-contrib/vfx/${QT5_GIT_BRANCH} https://github.com/autodesk-forks/qtx11extras.git /workdir/adsk/qtx11extras && \
+    git clone --recursive --branch adsk-contrib/vfx/${QT5_GIT_BRANCH} https://github.com/autodesk-forks/qtdeclarative.git /workdir/adsk/qtdeclarative && \
     # Revert to commit SHA for qtbase
     cd /workdir/adsk/qtbase && \
     git checkout ${ADSK_QTBASE_GIT_COMMIT} && \
     # Revert to commit SHA for qtx11extras
     cd /workdir/adsk/qtx11extras && \
     git checkout ${ADSK_QTX11EXTRAS_GIT_COMMIT} && \
+    # Revert to commit SHA for qtdeclarative
+    cd /workdir/adsk/qtdeclarative && \
+    git checkout ${ADSK_QTDECLARATIVE_GIT_COMMIT} && \
     # Move Autodesk sources into qt5
     mv /workdir/adsk/qtbase /workdir/qt5 && \
     mv /workdir/adsk/qtx11extras /workdir/qt5 && \
+    mv /workdir/adsk/qtdeclarative /workdir/qt5 && \
     # Build
     cd /workdir/qt5 && \
     # ./configure -help && \

--- a/Dockerfile.vfxplatform2018-update1
+++ b/Dockerfile.vfxplatform2018-update1
@@ -533,11 +533,10 @@ RUN \
     cd PyQt-x11-gpl-${PYQT4_VER} && \
     # python${PYTHON27_VER} configure-ng.py \
     scl enable devtoolset-6 'python${PYTHON27_VER} configure.py \
-        # --verbose \
         --confirm-license \
         # --qmake=/usr/bin/qmake-qt4 \
-        --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake && \
-        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip' && \
+        --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake' && \
+        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip && \
     scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
     scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/* && \
@@ -552,8 +551,8 @@ RUN \
         # --verbose \
         --confirm-license \
         # --qmake=/usr/bin/qmake-qt4 \
-        --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake && \
-        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip' && \
+        --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake' && \
+        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip && \
     scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
     scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/* && \
@@ -568,8 +567,8 @@ RUN \
         # --verbose \
         --confirm-license \
         # --qmake=/usr/bin/qmake-qt4 \
-        --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake && \
-        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip' && \
+        --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake' && \
+        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip && \
     scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
     scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/* && \
@@ -584,8 +583,8 @@ RUN \
         # --verbose \
         --confirm-license \
         # --qmake=/usr/bin/qmake-qt4 \
-        --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake && \
-        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip' && \
+        --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake' && \
+        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip && \
     scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
     scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/*

--- a/Dockerfile.vfxplatform2018-update1
+++ b/Dockerfile.vfxplatform2018-update1
@@ -7,8 +7,12 @@ RUN yum install deltarpm -y && \
         # cmake3 requirements
             epel-release && \
     yum install -y \
+        # gcc 5.3.1 (via Devtools which is equivalent of RedHat DTS)
+            devtoolset-4-gcc*-5.3.1 \
+            make \
         # gcc 6.3.1 (via Devtools which is equivalent of RedHat DTS)
             devtoolset-6-gcc*-6.3.1 \
+            devtoolset-6-make* \
         # glibc 2.17
             glibc-*-2.17 \
         # Qt5 requirements
@@ -60,7 +64,8 @@ RUN yum install deltarpm -y && \
             valgrind-devel \
         # PySide2 requirements
             # https://wiki.qt.io/PySide2_GettingStarted
-                libxslt libxml2 libxml2-devel libxslt-devel cmake3 openssl* \
+                libxslt libxml2 libxml2-devel libxslt-devel openssl* \
+                # cmake3 \
         # PySide
             # cmake gcc gcc-c++ make python-devel python-pip \
             libxml2-devel libxslt-devel rpmdevtools \
@@ -89,16 +94,17 @@ ENV BUILD_THREADS=17
 WORKDIR /workdir
 
 
-# Activate devtoolset-6 gcc 6.3.1
-# RUN scl enable devtoolset-6 bash
-ENV PATH="/opt/rh/devtoolset-6/root/usr/bin:${PATH}"
-ENV CC=/opt/rh/devtoolset-6/root/usr/bin/gcc
-ENV CXX=/opt/rh/devtoolset-6/root/usr/bin/g++
+# Run comand with devtoolset-6 gcc 6.3.1:
+# RUN scl enable devtoolset-6 'echo hello'
+# Run comand with devtoolset-4 gcc 5.3.1:
+# RUN scl enable devtoolset-4 'echo hello'
+
 
 # # Check gcc version
-# RUN gcc --version
+# RUN scl enable devtoolset-6 'gcc --version'
 # # Check glibc
-# RUN ldd --version
+# RUN scl enable devtoolset-6 'ldd --version'
+
 
 # Cmake3
 # https://cmake.org/install/
@@ -108,12 +114,12 @@ RUN \
     wget https://cmake.org/files/v3.9/cmake-${CMAKE_VER}.tar.gz && \
     tar xzf cmake-${CMAKE_VER}.tar.gz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap && \
-    make && \
-    make install && \
+    scl enable devtoolset-6 './bootstrap' && \
+    scl enable devtoolset-6 'make' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/*
 # Check cmake version
-#RUN cmake --version
+# RUN cmake --version
 
 
 # Git 2.14 with "git clone --jobs" functionality and "git checkout --recurse-submodules"
@@ -124,8 +130,8 @@ RUN \
     wget https://www.kernel.org/pub/software/scm/git/git-${GIT_VER}.tar.gz && \
     tar xzf git-${GIT_VER}.tar.gz && \
     cd git-${GIT_VER} && \
-    make -j${BUILD_THREADS} prefix=/usr/local/git all && \
-    make prefix=/usr/local/git install && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS} prefix=/usr/local/git all' && \
+    scl enable devtoolset-6 'make prefix=/usr/local/git install' && \
     rm -rf /workdir/*
 ENV PATH="/usr/local/git/bin:${PATH}"
 
@@ -141,18 +147,14 @@ RUN \
     cd qt && \
     git checkout ${QT4_GIT_COMMIT} && \
     git submodule update --init --recursive && \
-   ./configure \
+    scl enable devtoolset-4 './configure \
         -opensource \
         -confirm-license \
         -nomake examples \
-        -nomake tests
-RUN \
-    cd qt && \
-    gmake -j${BUILD_THREADS}
+        -nomake tests' && \
+    scl enable devtoolset-4 'gmake -j${BUILD_THREADS}' && \
     # Install
-RUN \
-    cd qt && \
-    gmake install && \
+    scl enable devtoolset-4 'gmake install' && \
     # Clean up
     rm -rf /workdir/*
 
@@ -205,14 +207,14 @@ RUN \
     # Build
     cd /workdir/qt5 && \
     # ./configure -help && \
-    ./configure \
+    scl enable devtoolset-6 './configure \
         -opensource \
         -confirm-license \
         -nomake examples \
-        -nomake tests && \
-    make -j${BUILD_THREADS} && \
+        -nomake tests' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
     # Install
-    make install && \
+    scl enable devtoolset-6 'make install' && \
     # Clean up
     rm -rf /workdir/*
 
@@ -231,9 +233,9 @@ RUN \
     git submodule update --init --recursive && \
     mkdir /workdir/qt-creator-build && \
     cd /workdir/qt-creator-build && \
-    /usr/local/Qt-${QT5_GIT_BRANCH}/bin/qmake -r /workdir/qt-creator/qtcreator.pro && \
-    make -j${BUILD_THREADS} && \
-    make install INSTALL_ROOT=/usr/local/qtcreator && \
+    scl enable devtoolset-6 '/usr/local/Qt-${QT5_GIT_BRANCH}/bin/qmake -r /workdir/qt-creator/qtcreator.pro' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install INSTALL_ROOT=/usr/local/qtcreator' && \
     rm -rf /workdir/*
 
 
@@ -261,7 +263,7 @@ RUN \
     # $ python
     # >>> from distutils.sysconfig import get_config_var
     # >>> print get_config_var('CONFIG_ARGS')
-    ./configure \
+    scl enable devtoolset-6 './configure \
         --prefix=/usr/local/python${PYTHON27_VER} \
         --enable-shared \
         --enable-unicode=ucs4 \
@@ -278,9 +280,9 @@ RUN \
         host_alias=x86_64-redhat-linux-gnu \
         CC=gcc \
         CFLAGS="-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv" \
-        CPPFLAGS="-I/usr/lib64/libffi-3.0.5/include" && \
-    make -j${BUILD_THREADS} && \
-    make altinstall && \
+        CPPFLAGS="-I/usr/lib64/libffi-3.0.5/include"' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make altinstall' && \
     cd /workdir && \
     wget https://bootstrap.pypa.io/get-pip.py && \
     /usr/local/python${PYTHON27_VER}/bin/python${PYTHON27_VER} get-pip.py && \
@@ -297,7 +299,7 @@ RUN \
     # $ python
     # >>> from distutils.sysconfig import get_config_var
     # >>> print(get_config_var('CONFIG_ARGS'))
-    ./configure \
+    scl enable devtoolset-6 './configure \
         --prefix=/usr/local/python${PYTHON34_VER} \
         --enable-shared \
         LDFLAGS="-Wl,-rpath /usr/local/python${PYTHON34_VER}/lib" \
@@ -316,9 +318,9 @@ RUN \
         CC=gcc \
         CFLAGS="-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv" \
         CPPFLAGS="-I/usr/lib64/libffi-3.0.5/include" \
-        PKG_CONFIG_PATH=":/usr/lib64/pkgconfig:/usr/share/pkgconfig" && \
-    make -j${BUILD_THREADS} && \
-    make altinstall && \
+        PKG_CONFIG_PATH=":/usr/lib64/pkgconfig:/usr/share/pkgconfig"' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make altinstall' && \
     cd /workdir && \
     wget https://bootstrap.pypa.io/get-pip.py && \
     /usr/local/python${PYTHON34_VER}/bin/python${PYTHON34_VER} get-pip.py && \
@@ -335,7 +337,7 @@ RUN \
     # $ python
     # >>> from distutils.sysconfig import get_config_var
     # >>> print(get_config_var('CONFIG_ARGS'))
-    ./configure \
+    scl enable devtoolset-6 './configure \
         --prefix=/usr/local/python${PYTHON35_VER} \
         --enable-shared \
         LDFLAGS="-Wl,-rpath /usr/local/python${PYTHON35_VER}/lib" \
@@ -354,9 +356,9 @@ RUN \
         CC=gcc \
         CFLAGS="-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv" \
         CPPFLAGS="-I/usr/lib64/libffi-3.0.5/include" \
-        PKG_CONFIG_PATH=":/usr/lib64/pkgconfig:/usr/share/pkgconfig" && \
-    make -j${BUILD_THREADS} && \
-    make altinstall && \
+        PKG_CONFIG_PATH=":/usr/lib64/pkgconfig:/usr/share/pkgconfig"' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make altinstall' && \
     cd /workdir && \
     wget https://bootstrap.pypa.io/get-pip.py && \
     /usr/local/python${PYTHON35_VER}/bin/python${PYTHON35_VER} get-pip.py && \
@@ -374,7 +376,7 @@ RUN \
     # $ python
     # >>> from distutils.sysconfig import get_config_var
     # >>> print(get_config_var('CONFIG_ARGS'))
-    ./configure \
+    scl enable devtoolset-6 './configure \
         --prefix=/usr/local/python${PYTHON36_VER} \
         --enable-shared \
         LDFLAGS="-Wl,-rpath /usr/local/python${PYTHON36_VER}/lib" \
@@ -393,9 +395,9 @@ RUN \
         CC=gcc \
         CFLAGS="-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv" \
         CPPFLAGS="-I/usr/lib64/libffi-3.0.5/include" \
-        PKG_CONFIG_PATH=":/usr/lib64/pkgconfig:/usr/share/pkgconfig" && \
-    make -j${BUILD_THREADS} && \
-    make altinstall && \
+        PKG_CONFIG_PATH=":/usr/lib64/pkgconfig:/usr/share/pkgconfig"' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make altinstall' && \
     cd /workdir && \
     wget https://bootstrap.pypa.io/get-pip.py && \
     /usr/local/python${PYTHON36_VER}/bin/python${PYTHON36_VER} get-pip.py && \
@@ -482,8 +484,8 @@ RUN \
     tar -xvf sip-${SIP_VER}.tar.gz && \
     cd sip-${SIP_VER} && \
     python${PYTHON27_VER} configure.py && \
-    make -j${BUILD_THREADS} && \
-    make install && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/* && \
 
     # Python 3.4
@@ -492,8 +494,8 @@ RUN \
     tar -xvf sip-${SIP_VER}.tar.gz && \
     cd sip-${SIP_VER} && \
     python${PYTHON34_VER} configure.py && \
-    make -j${BUILD_THREADS} && \
-    make install && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/* && \
 
     # Python 3.5
@@ -502,8 +504,8 @@ RUN \
     tar -xvf sip-${SIP_VER}.tar.gz && \
     cd sip-${SIP_VER} && \
     python${PYTHON35_VER} configure.py && \
-    make -j${BUILD_THREADS} && \
-    make install && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/* && \
 
     # Python 3.6
@@ -512,8 +514,8 @@ RUN \
     tar -xvf sip-${SIP_VER}.tar.gz && \
     cd sip-${SIP_VER} && \
     python${PYTHON36_VER} configure.py && \
-    make -j${BUILD_THREADS} && \
-    make install && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/*
 
 
@@ -527,14 +529,14 @@ RUN \
     tar -xvf PyQt-x11-gpl-${PYQT4_VER}.tar.gz && \
     cd PyQt-x11-gpl-${PYQT4_VER} && \
     # python${PYTHON27_VER} configure-ng.py \
-    python${PYTHON27_VER} configure.py \
+    scl enable devtoolset-6 'python${PYTHON27_VER} configure.py \
         # --verbose \
         --confirm-license \
         # --qmake=/usr/bin/qmake-qt4 \
         --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake && \
-        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip && \
-    make -j${BUILD_THREADS} && \
-    make install && \
+        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/* && \
 
     # PyQt4 for Python 3.4
@@ -543,14 +545,14 @@ RUN \
     tar -xvf PyQt-x11-gpl-${PYQT4_VER}.tar.gz && \
     cd PyQt-x11-gpl-${PYQT4_VER} && \
     # python${PYTHON34_VER} configure-ng.py \
-    python${PYTHON34_VER} configure.py \
+    scl enable devtoolset-6 'python${PYTHON34_VER} configure.py \
         # --verbose \
         --confirm-license \
         # --qmake=/usr/bin/qmake-qt4 \
         --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake && \
-        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip && \
-    make -j${BUILD_THREADS} && \
-    make install && \
+        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/* && \
 
     # PyQt4 for Python 3.5
@@ -559,14 +561,14 @@ RUN \
     tar -xvf PyQt-x11-gpl-${PYQT4_VER}.tar.gz && \
     cd PyQt-x11-gpl-${PYQT4_VER} && \
     # python${PYTHON35_VER} configure-ng.py \
-    python${PYTHON35_VER} configure.py \
+    scl enable devtoolset-6 'python${PYTHON35_VER} configure.py \
         # --verbose \
         --confirm-license \
         # --qmake=/usr/bin/qmake-qt4 \
         --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake && \
-        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip && \
-    make -j${BUILD_THREADS} && \
-    make install && \
+        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/* && \
 
     # PyQt4 for Python 3.6
@@ -575,14 +577,14 @@ RUN \
     tar -xvf PyQt-x11-gpl-${PYQT4_VER}.tar.gz && \
     cd PyQt-x11-gpl-${PYQT4_VER} && \
     # python${PYTHON36_VER} configure-ng.py \
-    python${PYTHON36_VER} configure.py \
+    scl enable devtoolset-6 'python${PYTHON36_VER} configure.py \
         # --verbose \
         --confirm-license \
         # --qmake=/usr/bin/qmake-qt4 \
         --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake && \
-        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip && \
-    make -j${BUILD_THREADS} && \
-    make install && \
+        # --sip=/usr/local/python${PYTHON27_VER}/bin/sip' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/*
 
 
@@ -598,12 +600,12 @@ RUN \
     cd pyside-setup && \
     git checkout ${PYSIDE_GIT_COMMIT} && \
     git submodule update --init --recursive && \
-    python${PYTHON27_VER} setup.py \
+    scl enable devtoolset-6 'python${PYTHON27_VER} setup.py \
         install \
             --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake \
             --cmake=/usr/local/bin/cmake \
             --openssl=/usr/bin/openssl \
-            --jobs=${BUILD_THREADS} && \
+            --jobs=${BUILD_THREADS}' && \
     rm -rf /workdir/* && \
 
     # PySide for Python 3.4
@@ -612,12 +614,12 @@ RUN \
     cd pyside-setup && \
     git checkout ${PYSIDE_GIT_COMMIT} && \
     git submodule update --init --recursive && \
-    python${PYTHON34_VER} setup.py \
+    scl enable devtoolset-6 'python${PYTHON34_VER} setup.py \
         install \
             --qmake=/usr/local/Trolltech/Qt-4.8.7/bin/qmake \
             --cmake=/usr/local/bin/cmake \
             --openssl=/usr/bin/openssl \
-            --jobs=${BUILD_THREADS} && \
+            --jobs=${BUILD_THREADS}' && \
     rm -rf /workdir/*
 # Ugly fix to make PySide find the Qt4 libs
 ENV LD_LIBRARY_PATH="/usr/local/Trolltech/Qt-4.8.7/lib:${LD_LIBRARY_PATH}"
@@ -631,13 +633,13 @@ RUN \
     wget http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-${PYQT5_VER}/PyQt5_gpl-${PYQT5_VER}.tar.gz && \
     tar -xvf PyQt5_gpl-${PYQT5_VER}.tar.gz && \
     cd PyQt5_gpl-${PYQT5_VER} && \
-    python${PYTHON27_VER} configure.py \
+    scl enable devtoolset-6 'python${PYTHON27_VER} configure.py \
         # --verbose \
         --confirm-license \
         --qmake=/usr/local/Qt-${QT5_GIT_BRANCH}/bin/qmake \
-        --sip=/usr/local/python${PYTHON27_VER}/bin/sip && \
-    make -j${BUILD_THREADS} && \
-    make install && \
+        --sip=/usr/local/python${PYTHON27_VER}/bin/sip' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/* && \
 
     # PyQt5 for Python 3.4
@@ -645,13 +647,13 @@ RUN \
     wget http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-${PYQT5_VER}/PyQt5_gpl-${PYQT5_VER}.tar.gz && \
     tar -xvf PyQt5_gpl-${PYQT5_VER}.tar.gz && \
     cd PyQt5_gpl-${PYQT5_VER} && \
-    python${PYTHON34_VER} configure.py \
+    scl enable devtoolset-6 'python${PYTHON34_VER} configure.py \
         # --verbose \
         --confirm-license \
         --qmake=/usr/local/Qt-${QT5_GIT_BRANCH}/bin/qmake \
-        --sip=/usr/local/python${PYTHON34_VER}/bin/sip && \
-    make -j${BUILD_THREADS} && \
-    make install && \
+        --sip=/usr/local/python${PYTHON34_VER}/bin/sip' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/* && \
 
     # PyQt5 for Python 3.5
@@ -659,13 +661,13 @@ RUN \
     wget http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-${PYQT5_VER}/PyQt5_gpl-${PYQT5_VER}.tar.gz && \
     tar -xvf PyQt5_gpl-${PYQT5_VER}.tar.gz && \
     cd PyQt5_gpl-${PYQT5_VER} && \
-    python${PYTHON35_VER} configure.py \
+    scl enable devtoolset-6 'python${PYTHON35_VER} configure.py \
         # --verbose \
         --confirm-license \
         --qmake=/usr/local/Qt-${QT5_GIT_BRANCH}/bin/qmake \
-        --sip=/usr/local/python${PYTHON35_VER}/bin/sip && \
-    make -j${BUILD_THREADS} && \
-    make install && \
+        --sip=/usr/local/python${PYTHON35_VER}/bin/sip' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/* && \
 
     # PyQt5 for Python 3.6
@@ -673,13 +675,13 @@ RUN \
     wget http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-${PYQT5_VER}/PyQt5_gpl-${PYQT5_VER}.tar.gz && \
     tar -xvf PyQt5_gpl-${PYQT5_VER}.tar.gz && \
     cd PyQt5_gpl-${PYQT5_VER} && \
-    python${PYTHON36_VER} configure.py \
+    scl enable devtoolset-6 'python${PYTHON36_VER} configure.py \
         # --verbose \
         --confirm-license \
         --qmake=/usr/local/Qt-${QT5_GIT_BRANCH}/bin/qmake \
-        --sip=/usr/local/python${PYTHON36_VER}/bin/sip && \
-    make -j${BUILD_THREADS} && \
-    make install && \
+        --sip=/usr/local/python${PYTHON36_VER}/bin/sip' && \
+    scl enable devtoolset-6 'make -j${BUILD_THREADS}' && \
+    scl enable devtoolset-6 'make install' && \
     rm -rf /workdir/*
 
 
@@ -699,14 +701,14 @@ RUN \
     sed -i -e "s~\b\(packages\b.*\)],~\1, 'pyside2uic.Compiler', 'pyside2uic.port_v' + str(sys.version_info[0])],~" setup.py && \
     # cat setup.py && \
 
-    python${PYTHON27_VER} setup.py \
+    scl enable devtoolset-6 'python${PYTHON27_VER} setup.py \
         # bdist_wheel \
         install \
             --ignore-git \
             --qmake=/usr/local/Qt-${QT5_GIT_BRANCH}/bin/qmake \
             --cmake=/usr/local/bin/cmake \
             --openssl=/usr/bin/openssl \
-            --jobs=${BUILD_THREADS} && \
+            --jobs=${BUILD_THREADS}' && \
     # pip install /workdir/pyside-setup/dist/*.whl
     rm -rf /workdir/* && \
 
@@ -721,14 +723,14 @@ RUN \
     sed -i -e "s~\b\(packages\b.*\)],~\1, 'pyside2uic.Compiler', 'pyside2uic.port_v' + str(sys.version_info[0])],~" setup.py && \
     # cat setup.py && \
 
-    python${PYTHON34_VER} setup.py \
+    scl enable devtoolset-6 'python${PYTHON34_VER} setup.py \
         # bdist_wheel \
         install \
             --ignore-git \
             --qmake=/usr/local/Qt-${QT5_GIT_BRANCH}/bin/qmake \
             --cmake=/usr/local/bin/cmake \
             --openssl=/usr/bin/openssl \
-            --jobs=${BUILD_THREADS} && \
+            --jobs=${BUILD_THREADS}' && \
     # pip install /workdir/pyside-setup/dist/*.whl
     rm -rf /workdir/* && \
 
@@ -743,14 +745,14 @@ RUN \
     sed -i -e "s~\b\(packages\b.*\)],~\1, 'pyside2uic.Compiler', 'pyside2uic.port_v' + str(sys.version_info[0])],~" setup.py && \
     # cat setup.py && \
 
-    python${PYTHON35_VER} setup.py \
+    scl enable devtoolset-6 'python${PYTHON35_VER} setup.py \
         # bdist_wheel \
         install \
             --ignore-git \
             --qmake=/usr/local/Qt-${QT5_GIT_BRANCH}/bin/qmake \
             --cmake=/usr/local/bin/cmake \
             --openssl=/usr/bin/openssl \
-            --jobs=${BUILD_THREADS} && \
+            --jobs=${BUILD_THREADS}' && \
     # pip install /workdir/pyside-setup/dist/*.whl
     rm -rf /workdir/* && \
 
@@ -765,14 +767,14 @@ RUN \
     sed -i -e "s~\b\(packages\b.*\)],~\1, 'pyside2uic.Compiler', 'pyside2uic.port_v' + str(sys.version_info[0])],~" setup.py && \
     # cat setup.py && \
 
-    python${PYTHON36_VER} setup.py \
+    scl enable devtoolset-6 'python${PYTHON36_VER} setup.py \
         # bdist_wheel \
         install \
             --ignore-git \
             --qmake=/usr/local/Qt-${QT5_GIT_BRANCH}/bin/qmake \
             --cmake=/usr/local/bin/cmake \
             --openssl=/usr/bin/openssl \
-            --jobs=${BUILD_THREADS} && \
+            --jobs=${BUILD_THREADS}' && \
     # pip install /workdir/pyside-setup/dist/*.whl
     rm -rf /workdir/*
 # Ugly fix to make PySide2 find the Qt5 libs
@@ -794,7 +796,7 @@ RUN dbus-uuidgen > /var/lib/dbus/machine-id
 
 
 # VFX Platform
-ENV VFXPLATFORM 2018
+ENV VFXPLATFORM 2018-update1
 
 # Enable additional output from Qt.py
 ENV QT_VERBOSE true

--- a/Dockerfile.vfxplatform2018-update1
+++ b/Dockerfile.vfxplatform2018-update1
@@ -173,7 +173,7 @@ ENV QT5_GIT_BRANCH=5.6.1
 ENV QT5_GIT_COMMIT=4566f0ac50e5ea143943c1251028fb01c70289ce
 ENV ADSK_QTBASE_GIT_COMMIT=c4e51d0162f7619c83e25e623ecd3bc549932040
 ENV ADSK_QTX11EXTRAS_GIT_COMMIT=c6c59d5d902db8be3661cab929be85a38fda0faa
-ENV ADSK_QTDECLARATIVE_GIT_COMMIT=b14cd49f891327d8fa5f5607eb19288ca137c5e2
+# ENV ADSK_QTDECLARATIVE_GIT_COMMIT=b14cd49f891327d8fa5f5607eb19288ca137c5e2
 
 RUN \
     git clone --recursive --jobs ${BUILD_THREADS} --branch ${QT5_GIT_BRANCH} https://code.qt.io/qt/qt5.git && \
@@ -185,12 +185,13 @@ RUN \
     cd /workdir && \
     rm -rf /workdir/qt5/qtbase && \
     rm -rf /workdir/qt5/qtx11extras && \
+    # rm -rf /workdir/qt5/qtdeclarative && \
     # Clone Autodesk's qtbase, qtx11extras
     cd /workdir && \
     mkdir -p /workdir/adsk && \
     git clone --recursive --branch adsk-contrib/vfx/${QT5_GIT_BRANCH} https://github.com/autodesk-forks/qtbase.git /workdir/adsk/qtbase && \
     git clone --recursive --branch adsk-contrib/vfx/${QT5_GIT_BRANCH} https://github.com/autodesk-forks/qtx11extras.git /workdir/adsk/qtx11extras && \
-    git clone --recursive --branch adsk-contrib/vfx/${QT5_GIT_BRANCH} https://github.com/autodesk-forks/qtdeclarative.git /workdir/adsk/qtdeclarative && \
+    # git clone --recursive --branch adsk-contrib/vfx/${QT5_GIT_BRANCH} https://github.com/autodesk-forks/qtdeclarative.git /workdir/adsk/qtdeclarative && \
     # Revert to commit SHA for qtbase
     cd /workdir/adsk/qtbase && \
     git checkout ${ADSK_QTBASE_GIT_COMMIT} && \
@@ -198,12 +199,13 @@ RUN \
     cd /workdir/adsk/qtx11extras && \
     git checkout ${ADSK_QTX11EXTRAS_GIT_COMMIT} && \
     # Revert to commit SHA for qtdeclarative
-    cd /workdir/adsk/qtdeclarative && \
-    git checkout ${ADSK_QTDECLARATIVE_GIT_COMMIT} && \
+    # cd /workdir/adsk/qtdeclarative && \
+    # git checkout ${ADSK_QTDECLARATIVE_GIT_COMMIT} && \
     # Move Autodesk sources into qt5
     mv /workdir/adsk/qtbase /workdir/qt5 && \
     mv /workdir/adsk/qtx11extras /workdir/qt5 && \
-    mv /workdir/adsk/qtdeclarative /workdir/qt5 && \
+    # Cannot include qtdeclarative for some reason:
+    # mv /workdir/adsk/qtdeclarative /workdir/qt5 && \
     # Build
     cd /workdir/qt5 && \
     # ./configure -help && \
@@ -227,8 +229,9 @@ RUN \
 ENV QT5CREATOR_VER=4.3
 ENV QT5CREATOR_GIT_COMMIT=a094841bdda5461ebeaeab4620dde8222fa8312d
 RUN \
-    git clone --recursive --branch ${QT5CREATOR_VER} --jobs ${BUILD_THREADS} https://code.qt.io/qt-creator/qt-creator.git && \
+    git clone --branch ${QT5CREATOR_VER} --jobs ${BUILD_THREADS} https://code.qt.io/qt-creator/qt-creator.git && \
     cd /workdir/qt-creator && \
+    sed -i 's/qt-labs/qbs/g' .gitmodules && \
     git checkout ${QT5CREATOR_GIT_COMMIT} && \
     git submodule update --init --recursive && \
     mkdir /workdir/qt-creator-build && \

--- a/README.md
+++ b/README.md
@@ -501,16 +501,16 @@ With Docker setup, here's what you do. Please note this will pull down a ~1 GB i
 cd Qt.py
 
 # Run nosetests (Linux/OSX)
-docker run --rm -v $(pwd):/Qt.py -e PYTHON=2.7 fredrikaverpil/qt.py:2018
-docker run --rm -v $(pwd):/Qt.py -e PYTHON=3.4 fredrikaverpil/qt.py:2018
-docker run --rm -v $(pwd):/Qt.py -e PYTHON=3.5 fredrikaverpil/qt.py:2018
-docker run --rm -v $(pwd):/Qt.py -e PYTHON=3.6 fredrikaverpil/qt.py:2018
+docker run --rm -v $(pwd):/Qt.py -e PYTHON=2.7 fredrikaverpil/qt.py:2018-update1
+docker run --rm -v $(pwd):/Qt.py -e PYTHON=3.4 fredrikaverpil/qt.py:2018-update1
+docker run --rm -v $(pwd):/Qt.py -e PYTHON=3.5 fredrikaverpil/qt.py:2018-update1
+docker run --rm -v $(pwd):/Qt.py -e PYTHON=3.6 fredrikaverpil/qt.py:2018-update1
 
 # Run nosetests (Windows)
-docker run --rm -v %CD%:/Qt.py -e PYTHON=2.7 fredrikaverpil/qt.py:2018
-docker run --rm -v %CD%:/Qt.py -e PYTHON=3.4 fredrikaverpil/qt.py:2018
-docker run --rm -v %CD%:/Qt.py -e PYTHON=3.5 fredrikaverpil/qt.py:2018
-docker run --rm -v %CD%:/Qt.py -e PYTHON=3.6 fredrikaverpil/qt.py:2018
+docker run --rm -v %CD%:/Qt.py -e PYTHON=2.7 fredrikaverpil/qt.py:2018-update1
+docker run --rm -v %CD%:/Qt.py -e PYTHON=3.4 fredrikaverpil/qt.py:2018-update1
+docker run --rm -v %CD%:/Qt.py -e PYTHON=3.5 fredrikaverpil/qt.py:2018-update1
+docker run --rm -v %CD%:/Qt.py -e PYTHON=3.6 fredrikaverpil/qt.py:2018-update1
 
 # Doctest: test_caveats.test_1_qtgui_qabstractitemmodel_createindex ... ok
 # Doctest: test_caveats.test_2_qtgui_qabstractitemmodel_createindex ... ok


### PR DESCRIPTION
There was one late change to the CY2018 [VFX Platform](http://www.vfxplatform.com/):

> **26th November 2017** - CY2018 has had a late change to the compiler version which is now gcc 6.3.1. This successfully resolves issues that were discovered with gcc 5.3.1.

Also, `qtdeclarative` was added:

> **28th August 2017** - Added a note for gcc 5 and updated the Qt note to include a link to the qtdeclarative modifications.

This PR aims to address these additions.

### How to's

    # Build new image
    docker build . -t fredrikaverpil/qt.py:2018-update1 -f Dockerfile.vfxplatform2018-update1

    # Run tests locally, Unix
    docker run --rm -v $(pwd):/Qt.py -e PYTHON=2.7 fredrikaverpil/qt.py:2018-update1
    docker run --rm -v $(pwd):/Qt.py -e PYTHON=3.4 fredrikaverpil/qt.py:2018-update1
    docker run --rm -v $(pwd):/Qt.py -e PYTHON=3.5 fredrikaverpil/qt.py:2018-update1
    docker run --rm -v $(pwd):/Qt.py -e PYTHON=3.6 fredrikaverpil/qt.py:2018-update1

    # Run tests locally, Windows
    docker run --rm -v %CD%:/Qt.py -e PYTHON=2.7 fredrikaverpil/qt.py:2018-update1
    docker run --rm -v %CD%:/Qt.py -e PYTHON=3.4 fredrikaverpil/qt.py:2018-update1
    docker run --rm -v %CD%:/Qt.py -e PYTHON=3.5 fredrikaverpil/qt.py:2018-update1
    docker run --rm -v %CD%:/Qt.py -e PYTHON=3.6 fredrikaverpil/qt.py:2018-update1

