### PR TITLE
Add from Qt.QtCompat import support

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -1546,6 +1546,9 @@ def _install():
 
             setattr(our_submodule, member, their_member)
 
+    # Enable direct import of QtCompat
+    sys.modules['Qt.QtCompat'] = Qt.QtCompat
+
     # Backwards compatibility
     if hasattr(Qt.QtCompat, 'loadUi'):
         Qt.QtCompat.load_ui = Qt.QtCompat.loadUi

--- a/Qt.py
+++ b/Qt.py
@@ -43,7 +43,7 @@ import types
 import shutil
 
 
-__version__ = "1.1.0.b9"
+__version__ = "1.1.0.b10"
 
 # Enable support for `from Qt import *`
 __all__ = []

--- a/tests.py
+++ b/tests.py
@@ -606,6 +606,12 @@ def test_import_from_qtwidgets():
     assert QPushButton.__name__ == "QPushButton", QPushButton
 
 
+def test_import_from_qtcompat():
+    """ `from Qt.QtCompat import XXX` works """
+    from Qt.QtCompat import loadUi
+    assert loadUi.__name__ == "_loadUi", loadUi
+
+
 def test_i158_qtcore_direct_import():
     """import Qt.QtCore works on all bindings
 


### PR DESCRIPTION
This pull request adds support for `from Qt.QtCompat import X` so it's consistent with the other Qt modules.