### PR TITLE
Misplaced members can't create Qt sub-modules

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -43,7 +43,7 @@ import types
 import shutil
 
 
-__version__ = "1.1.0.b10"
+__version__ = "1.1.0.b11"
 
 # Enable support for `from Qt import *`
 __all__ = []

--- a/Qt.py
+++ b/Qt.py
@@ -394,6 +394,16 @@ _common_members = {
         "QGLFormat",
         "QGLWidget"
     ],
+    "QtPrintSupport": [
+        "QAbstractPrintDialog",
+        "QPageSetupDialog",
+        "QPrintDialog",
+        "QPrintEngine",
+        "QPrintPreviewDialog",
+        "QPrintPreviewWidget",
+        "QPrinter",
+        "QPrinterInfo"
+    ],
     "QtSql": [
         "QSql",
         "QSqlDatabase",
@@ -706,6 +716,14 @@ _misplaced_members = {
         "QtCore.Signal": "QtCore.Signal",
         "QtCore.Slot": "QtCore.Slot",
         "QtGui.QItemSelectionRange": "QtCore.QItemSelectionRange",
+        "QtGui.QAbstractPrintDialog": "QtPrintSupport.QAbstractPrintDialog",
+        "QtGui.QPageSetupDialog": "QtPrintSupport.QPageSetupDialog",
+        "QtGui.QPrintDialog": "QtPrintSupport.QPrintDialog",
+        "QtGui.QPrintEngine": "QtPrintSupport.QPrintEngine",
+        "QtGui.QPrintPreviewDialog": "QtPrintSupport.QPrintPreviewDialog",
+        "QtGui.QPrintPreviewWidget": "QtPrintSupport.QPrintPreviewWidget",
+        "QtGui.QPrinter": "QtPrintSupport.QPrinter",
+        "QtGui.QPrinterInfo": "QtPrintSupport.QPrinterInfo",
     },
     "PyQt4": {
         "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
@@ -717,6 +735,14 @@ _misplaced_members = {
         "QtCore.pyqtSignal": "QtCore.Signal",
         "QtCore.pyqtSlot": "QtCore.Slot",
         "QtGui.QItemSelectionRange": "QtCore.QItemSelectionRange",
+        "QtGui.QAbstractPrintDialog": "QtPrintSupport.QAbstractPrintDialog",
+        "QtGui.QPageSetupDialog": "QtPrintSupport.QPageSetupDialog",
+        "QtGui.QPrintDialog": "QtPrintSupport.QPrintDialog",
+        "QtGui.QPrintEngine": "QtPrintSupport.QPrintEngine",
+        "QtGui.QPrintPreviewDialog": "QtPrintSupport.QPrintPreviewDialog",
+        "QtGui.QPrintPreviewWidget": "QtPrintSupport.QPrintPreviewWidget",
+        "QtGui.QPrinter": "QtPrintSupport.QPrinter",
+        "QtGui.QPrinterInfo": "QtPrintSupport.QPrinterInfo",
     }
 }
 

--- a/examples/QtSiteConfig/QtSiteConfig.py
+++ b/examples/QtSiteConfig/QtSiteConfig.py
@@ -8,12 +8,6 @@ def update_members(members):
     Arguments:
         members (dict): The members considered by Qt.py
     """
-    # By default Qt.py does not include QtPrintSupport, so lets add it.
-    members["QtPrintSupport"] = [
-        "QPrintPreviewWidget",
-        "QPrinter",
-    ]
-
     # Contrived example used for unit testing. This makes the QtCore module
     # not accessible. I chose this so it can be tested everywhere, for a
     # more realistic example see the README
@@ -27,16 +21,6 @@ def update_misplaced_members(members):
     Arguments:
         members (dict): The members considered by Qt.py
     """
-    # Printer support in Qt4 was stored under QtGui instead of QtPrintSupport
-    members["PyQt4"]["QtGui.QPrintPreviewWidget"] = (
-        "QtPrintSupport.QPrintPreviewWidget"
-    )
-    members["PyQt4"]["QtGui.QPrinter"] = "QtPrintSupport.QPrinter"
-    members["PySide"]["QtGui.QPrintPreviewWidget"] = (
-        "QtPrintSupport.QPrintPreviewWidget"
-    )
-    members["PySide"]["QtGui.QPrinter"] = "QtPrintSupport.QPrinter"
-
     # Create Qt.QtGui.QColorTest that points to Qtgui.QColor for unit testing.
     members["PySide2"]["QtGui.QColor"] = "QtGui.QColorTest"
     members["PyQt5"]["QtGui.QColor"] = "QtGui.QColorTest"

--- a/examples/QtSiteConfig/QtSiteConfig.py
+++ b/examples/QtSiteConfig/QtSiteConfig.py
@@ -9,9 +9,9 @@ def update_members(members):
         members (dict): The members considered by Qt.py
     """
     # By default Qt.py does not include QtPrintSupport, so lets add it.
-    members['QtPrintSupport'] = [
-        'QPrintPreviewWidget',
-        'QPrinter',
+    members["QtPrintSupport"] = [
+        "QPrintPreviewWidget",
+        "QPrinter",
     ]
 
     # Contrived example used for unit testing. This makes the QtCore module
@@ -28,12 +28,14 @@ def update_misplaced_members(members):
         members (dict): The members considered by Qt.py
     """
     # Printer support in Qt4 was stored under QtGui instead of QtPrintSupport
-    members['PyQt4']['QtGui.QPrintPreviewWidget'] = \
-        'QtPrintSupport.QPrintPreviewWidget'
-    members['PyQt4']['QtGui.QPrinter'] = 'QtPrintSupport.QPrinter'
-    members['PySide']['QtGui.QPrintPreviewWidget'] = \
-        'QtPrintSupport.QPrintPreviewWidget'
-    members['PySide']['QtGui.QPrinter'] = 'QtPrintSupport.QPrinter'
+    members["PyQt4"]["QtGui.QPrintPreviewWidget"] = (
+        "QtPrintSupport.QPrintPreviewWidget"
+    )
+    members["PyQt4"]["QtGui.QPrinter"] = "QtPrintSupport.QPrinter"
+    members["PySide"]["QtGui.QPrintPreviewWidget"] = (
+        "QtPrintSupport.QPrintPreviewWidget"
+    )
+    members["PySide"]["QtGui.QPrinter"] = "QtPrintSupport.QPrinter"
 
     # Create Qt.QtGui.QColorTest that points to Qtgui.QColor for unit testing.
     members["PySide2"]["QtGui.QColor"] = "QtGui.QColorTest"
@@ -97,7 +99,9 @@ def update_compatibility_decorators(binding, decorators):
         wrapper.__doc__ = some_function.__doc__
         wrapper.__name__ = some_function.__name__
         return wrapper
-    decorators.setdefault("QWidget", {})["windowTitleDecorator"] = \
+    decorators.setdefault("QWidget", {})["windowTitleDecorator"] = (
         _widgetDecorator
-    decorators.setdefault("QMainWindow", {})["windowTitleDecorator"] = \
+    )
+    decorators.setdefault("QMainWindow", {})["windowTitleDecorator"] = (
         _mainWindowDecorator
+    )

--- a/examples/QtSiteConfig/QtSiteConfig.py
+++ b/examples/QtSiteConfig/QtSiteConfig.py
@@ -8,6 +8,11 @@ def update_members(members):
     Arguments:
         members (dict): The members considered by Qt.py
     """
+    # By default Qt.py does not include QtPrintSupport, so lets add it.
+    members['QtPrintSupport'] = [
+        'QPrintPreviewWidget',
+        'QPrinter',
+    ]
 
     # Contrived example used for unit testing. This makes the QtCore module
     # not accessible. I chose this so it can be tested everywhere, for a
@@ -22,6 +27,15 @@ def update_misplaced_members(members):
     Arguments:
         members (dict): The members considered by Qt.py
     """
+    # Printer support in Qt4 was stored under QtGui instead of QtPrintSupport
+    members['PyQt4']['QtGui.QPrintPreviewWidget'] = \
+        'QtPrintSupport.QPrintPreviewWidget'
+    members['PyQt4']['QtGui.QPrinter'] = 'QtPrintSupport.QPrinter'
+    members['PySide']['QtGui.QPrintPreviewWidget'] = \
+        'QtPrintSupport.QPrintPreviewWidget'
+    members['PySide']['QtGui.QPrinter'] = 'QtPrintSupport.QPrinter'
+
+    # Create Qt.QtGui.QColorTest that points to Qtgui.QColor for unit testing.
     members["PySide2"]["QtGui.QColor"] = "QtGui.QColorTest"
     members["PyQt5"]["QtGui.QColor"] = "QtGui.QColorTest"
     members["PySide"]["QtGui.QColor"] = "QtGui.QColorTest"

--- a/examples/QtSiteConfig/main.py
+++ b/examples/QtSiteConfig/main.py
@@ -27,17 +27,21 @@ def test():
 
     # Test _misplaced_members is applied correctly
     from Qt import QtGui
-    assert QtGui.QColorTest == QtGui.QColor, \
+    assert QtGui.QColorTest == QtGui.QColor, (
         "QtGui.QColor was not mapped to QtGui.QColorTest"
+    )
 
     # Test that Qt.QtPrintSupport module was created correctly in all bindings
     from Qt import QtPrintSupport
-    assert QtPrintSupport.QPrintPreviewWidget.__name__ == \
-        'QPrintPreviewWidget', \
+    name = QtPrintSupport.QPrintPreviewWidget.__name__
+    assert name == "QPrintPreviewWidget", (
         "Qt.QtPrintSupport.QPrintPreviewWidget was not correctly mapped"
+    )
 
-    assert QtPrintSupport.QPrinter.__name__ == 'QPrinter', \
+    name = QtPrintSupport.QPrinter.__name__
+    assert name == "QPrinter", (
         "Qt.QtPrintSupport.QPrinter was not correctly mapped"
+    )
 
     # Test that we can import classes from inside QtPrintSupport
     from Qt.QtPrintSupport import QPrintPreviewWidget, QPrinter
@@ -53,20 +57,23 @@ def test():
     wid.setWindowTitle(title)
 
     # Verify that our simple remapping of QWidget.windowTitle works
-    assert QtCompat.QWidget.windowTitleTest(wid) == title, \
+    assert QtCompat.QWidget.windowTitleTest(wid) == title, (
         "Non-decorated function was added to QtCompat.QWidget"
+    )
     # Verify that our decorated remapping of QWidget.windowTitle works
     check = "Test: {}".format(title)
-    assert QtCompat.QWidget.windowTitleDecorator(wid) == check, \
+    assert QtCompat.QWidget.windowTitleDecorator(wid) == check, (
         "Decorated method was not added to QtCompat.QWidget"
+    )
 
     # Verify that our decorated remapping of QMainWindow.windowTitle is
     # different than the QWidget version.
     win = QtWidgets.QMainWindow()
     win.setWindowTitle(title)
     check = "QMainWindow Test: {}".format(title)
-    assert QtCompat.QMainWindow.windowTitleDecorator(win) == check, \
+    assert QtCompat.QMainWindow.windowTitleDecorator(win) == check, (
         "Decorated method was added to QtCompat.QMainWindow"
+    )
     # Suppress "app" imported but unused warning
     app
 

--- a/examples/QtSiteConfig/main.py
+++ b/examples/QtSiteConfig/main.py
@@ -32,10 +32,13 @@ def test():
 
     # Test that Qt.QtPrintSupport module was created correctly in all bindings
     from Qt import QtPrintSupport
-    assert QtPrintSupport.QPrintPreviewWidget.__name__ == 'QPrintPreviewWidget', \
+    assert QtPrintSupport.QPrintPreviewWidget.__name__ == \
+        'QPrintPreviewWidget', \
         "Qt.QtPrintSupport.QPrintPreviewWidget was not correctly mapped"
+
     assert QtPrintSupport.QPrinter.__name__ == 'QPrinter', \
         "Qt.QtPrintSupport.QPrinter was not correctly mapped"
+
     # Test that we can import classes from inside QtPrintSupport
     from Qt.QtPrintSupport import QPrintPreviewWidget, QPrinter
     # Suppress imported but unused warnings

--- a/examples/QtSiteConfig/main.py
+++ b/examples/QtSiteConfig/main.py
@@ -31,24 +31,6 @@ def test():
         "QtGui.QColor was not mapped to QtGui.QColorTest"
     )
 
-    # Test that Qt.QtPrintSupport module was created correctly in all bindings
-    from Qt import QtPrintSupport
-    name = QtPrintSupport.QPrintPreviewWidget.__name__
-    assert name == "QPrintPreviewWidget", (
-        "Qt.QtPrintSupport.QPrintPreviewWidget was not correctly mapped"
-    )
-
-    name = QtPrintSupport.QPrinter.__name__
-    assert name == "QPrinter", (
-        "Qt.QtPrintSupport.QPrinter was not correctly mapped"
-    )
-
-    # Test that we can import classes from inside QtPrintSupport
-    from Qt.QtPrintSupport import QPrintPreviewWidget, QPrinter
-    # Suppress imported but unused warnings
-    QPrintPreviewWidget
-    QPrinter
-
     # Test _compatibility_members is applied correctly
     title = "Test Widget"
     from Qt import QtWidgets, QtCompat

--- a/examples/QtSiteConfig/main.py
+++ b/examples/QtSiteConfig/main.py
@@ -30,6 +30,18 @@ def test():
     assert QtGui.QColorTest == QtGui.QColor, \
         "QtGui.QColor was not mapped to QtGui.QColorTest"
 
+    # Test that Qt.QtPrintSupport module was created correctly in all bindings
+    from Qt import QtPrintSupport
+    assert QtPrintSupport.QPrintPreviewWidget.__name__ == 'QPrintPreviewWidget', \
+        "Qt.QtPrintSupport.QPrintPreviewWidget was not correctly mapped"
+    assert QtPrintSupport.QPrinter.__name__ == 'QPrinter', \
+        "Qt.QtPrintSupport.QPrinter was not correctly mapped"
+    # Test that we can import classes from inside QtPrintSupport
+    from Qt.QtPrintSupport import QPrintPreviewWidget, QPrinter
+    # Suppress imported but unused warnings
+    QPrintPreviewWidget
+    QPrinter
+
     # Test _compatibility_members is applied correctly
     title = "Test Widget"
     from Qt import QtWidgets, QtCompat

--- a/membership.py
+++ b/membership.py
@@ -51,7 +51,7 @@ def compare(dicts):
     return common_members
 
 
-def copy_qtgui_to_qtwidgets():
+def copy_qtgui_to_modules():
     """Copies the QtGui list of PySide/PyQt4 into QtWidgets"""
 
     pyside_filepath = PREFIX + '/PySide.json'
@@ -59,8 +59,12 @@ def copy_qtgui_to_qtwidgets():
     pyside = read_json(pyside_filepath)
     pyqt4 = read_json(pyqt4_filepath)
 
+    # When Qt4 was moved to Qt5, they split QtGui into QtGui, QtWidgets, and
+    # QtPrintSupport.
     pyside['QtWidgets'] = pyside['QtGui']
     pyqt4['QtWidgets'] = pyqt4['QtGui']
+    pyside['QtPrintSupport'] = pyside['QtGui']
+    pyqt4['QtPrintSupport'] = pyqt4['QtGui']
 
     write_json(pyside, pyside_filepath)
     print('--> Copied QtGui to QtWidgets for ' + os.path.basename(
@@ -127,7 +131,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.copy:
-        copy_qtgui_to_qtwidgets()
+        copy_qtgui_to_modules()
 
     elif options.generate:
         generate_common_members()

--- a/membership.py
+++ b/membership.py
@@ -67,11 +67,11 @@ def copy_qtgui_to_modules():
     pyqt4['QtPrintSupport'] = pyqt4['QtGui']
 
     write_json(pyside, pyside_filepath)
-    print('--> Copied QtGui to QtWidgets for ' + os.path.basename(
-        pyside_filepath))
+    print('--> Copied QtGui to QtWidgets and QtPrintSupport for {0}'.format(
+        os.path.basename(pyside_filepath)))
     write_json(pyqt4, pyqt4_filepath)
-    print('--> Copied QtGui to QtWidgets for ' + os.path.basename(
-        pyqt4_filepath))
+    print('--> Copied QtGui to QtWidgets and QtPrintSupport for {0}'.format(
+        os.path.basename(pyqt4_filepath)))
 
 
 def sort_common_members():


### PR DESCRIPTION
Currently you can't use misplaced members to add new Qt modules like `Qt.QtPrintSupport` universally. It works for Qt5 because both PySide2 and PyQt5 have the QtPrintSupport module, but in Qt4, the print classes are stored on QtGui.

This patch gives `_reassign_misplaced_members` the ability to create missing modules like `Qt.QtPrintSupport`.

I modified the logic of how `_reassign_misplaced_members` rejects members a little bit from #212. If the destination method exists, but the source module was not created for Qt, it will create the module.