### PR TITLE
Add Compatibility members for #151

### DIFF
--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -10,6 +10,7 @@ There are cases where Qt.py is not handling incompatibility issues.
 - [QtWidgets.QHeaderView.setResizeMode](#qtwidgetsqheaderviewsetresizemode)
 - [QtWidgets.qApp](#qtwidgetsqapp)
 - [QtCompat.wrapInstance](#qtcompatwrapinstance)
+- [QtGui.QPixmap.grabWidget](#qtguiqpixmapgrabwidget)
 - [QtCore.qInstallMessageHandler](#qtcoreqinstallmessagehandler)
 
 <br>
@@ -63,7 +64,7 @@ True
 
 I had been using the id as an index into a list. But the unexpected return value from PyQt4 broke it by being invalid. The workaround was to always check that the returned id was between 0 and the max size I expect.  
 
-– @justinfx
+\- @justinfx
 
 
 <br>
@@ -352,3 +353,37 @@ True
 ```
 
 Note the `False` for PySide2 and `True` for PyQt5.
+
+#### QtGui.QPixmap.grabWidget
+
+The method of capturing a widget to a pixmap changed between Qt4 and Qt5.
+
+PySide and PyQt4:
+```python
+# PySide
+>>> from Qt import QtGui, QtWidgets
+>>> app = QtWidgets.QApplication(sys.argv)
+>>> button = QtWidgets.QPushButton("Hello world")
+>>> pixmap = QtGui.QPixmap.grabWidget(button)
+```
+
+PySide2 and PyQt5
+```python
+# PySide2
+>>> from Qt import QtGui, QtWidgets
+>>> app = QtWidgets.QApplication(sys.argv)
+>>> button = QtWidgets.QPushButton("Hello world")
+>>> pixmap = button.grab()
+```
+
+##### Workaround
+
+Use compatibility wrapper.
+
+```python
+# PySide2
+>>> from Qt import QtCompat, QtWidgets
+>>> app = QtWidgets.QApplication(sys.argv)
+>>> button = QtWidgets.QPushButton("Hello world")
+>>> pixmap = QtCompat.QWidget.grab(button)
+```

--- a/Qt.py
+++ b/Qt.py
@@ -43,7 +43,7 @@ import types
 import shutil
 
 
-__version__ = "1.1.0"
+__version__ = "1.2.0.b1"
 
 # Enable support for `from Qt import *`
 __all__ = []

--- a/Qt.py
+++ b/Qt.py
@@ -761,6 +761,9 @@ interface for obsolete members, and differences in binding return values.
 """
 _compatibility_members = {
     "PySide2": {
+        "QWidget": {
+            "grab": "QtWidgets.QWidget.grab",
+        },
         "QHeaderView": {
             "sectionsClickable": "QtWidgets.QHeaderView.sectionsClickable",
             "setSectionsClickable":
@@ -778,6 +781,9 @@ _compatibility_members = {
         },
     },
     "PyQt5": {
+        "QWidget": {
+            "grab": "QtWidgets.QWidget.grab",
+        },
         "QHeaderView": {
             "sectionsClickable": "QtWidgets.QHeaderView.sectionsClickable",
             "setSectionsClickable":
@@ -795,6 +801,9 @@ _compatibility_members = {
         },
     },
     "PySide": {
+        "QPixmap": {
+            "grabWidget": "QtWidgets.QWidget.grab",
+        },
         "QHeaderView": {
             "sectionsClickable": "QtWidgets.QHeaderView.isClickable",
             "setSectionsClickable": "QtWidgets.QHeaderView.setClickable",
@@ -810,6 +819,9 @@ _compatibility_members = {
         },
     },
     "PyQt4": {
+        "QPixmap": {
+            "grabWidget": "QtWidgets.QWidget.grab",
+        },
         "QHeaderView": {
             "sectionsClickable": "QtWidgets.QHeaderView.isClickable",
             "setSectionsClickable": "QtWidgets.QHeaderView.setClickable",

--- a/Qt.py
+++ b/Qt.py
@@ -801,8 +801,8 @@ _compatibility_members = {
         },
     },
     "PySide": {
-        "QPixmap": {
-            "grabWidget": "QtWidgets.QWidget.grab",
+        "QWidget": {
+            "grab": "QtWidgets.QPixmap.grabWidget",
         },
         "QHeaderView": {
             "sectionsClickable": "QtWidgets.QHeaderView.isClickable",
@@ -819,8 +819,8 @@ _compatibility_members = {
         },
     },
     "PyQt4": {
-        "QPixmap": {
-            "grabWidget": "QtWidgets.QWidget.grab",
+        "QWidget": {
+            "grab": "QtWidgets.QPixmap.grabWidget",
         },
         "QHeaderView": {
             "sectionsClickable": "QtWidgets.QHeaderView.isClickable",

--- a/tests.py
+++ b/tests.py
@@ -679,6 +679,11 @@ def test_qtcompat_base_class():
     QtCompat.QHeaderView.setSectionsMovable(header, True)
     assert QtCompat.QHeaderView.sectionsMovable(header) is True
 
+    # Verify that the grab function actually generates a non-null image
+    button = QtWidgets.QPushButton('TestImage')
+    pixmap = QtCompat.QWidget.grab(button)
+    assert not pixmap.isNull()
+
 
 def test_cli():
     """Qt.py is available from the command-line"""


### PR DESCRIPTION
In Qt5 QPixmap.grabWidget got moved to QWidget.grab.

This code moves the member to QtCompat.