### PR TITLE
Update to new location of QStringListModel in PySide2.

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -917,7 +917,7 @@ These members from the original submodule are misplaced relative PySide2
 """
 _misplaced_members = {
     "PySide2": {
-        "QtGui.QStringListModel": "QtCore.QStringListModel",
+        "QtCore.QStringListModel": "QtCore.QStringListModel",
         "QtCore.Property": "QtCore.Property",
         "QtCore.Signal": "QtCore.Signal",
         "QtCore.Slot": "QtCore.Slot",


### PR DESCRIPTION
QStringListModel was moved from QtGui to QtCore in Qt5. PySide2 kept it in QtGui for a while, but have now also moved it to QtCore. (See https://bugreports.qt.io/browse/PYSIDE-614.)

This means that Qt.py also need to update to be compatible with newer versions of PySide2.