### PR TITLE
trying to fix loadUi widget placement issue

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -930,12 +930,15 @@ def _loadUi(uifile, baseinstance=None):
                 if self.baseinstance:
                     # correct geometry on show
                     parent = self.baseinstance.parentWidget()
-                    if parent and hasattr(parent, 'geometry'):
+                    if parent and hasattr(parent, 'frameGeometry'):
                         geo = self.baseinstance.geometry()
                         pgeo = parent.geometry()
+                        pfgeo = parent.frameGeometry()
+                        hdiff = pfgeo.height() - pgeo.height()
                         self.baseinstance.move(
-                                pgeo.x() + pgeo.width()/2 - geo.width()/2,
-                                pgeo.y() + pgeo.height()/2 - geo.height()/2)
+                            pgeo.x() + pgeo.width()/2 - geo.width()/2,
+                            pgeo.y() + pgeo.height()/2 - geo.height()/2 -
+                            hdiff)
 
                 # Workaround for PySide 1.0.9, see issue #208
                 widget.parentWidget()

--- a/Qt.py
+++ b/Qt.py
@@ -927,6 +927,23 @@ def _loadUi(uifile, baseinstance=None):
                 widget = Qt._QtUiTools.QUiLoader.load(
                     self, uifile, *args, **kwargs)
 
+                if self.baseinstance:
+
+                    # copy over all the widgets and layouts from attributes
+                    for member in dir(widget):
+                        value = getattr(widget, member)
+                        if isinstance(value, Qt.QtCore.QObject):
+                            setattr(self.baseinstance, member, value)
+
+                    # poach main layouts and widgets
+                    if isinstance(widget, Qt.QtWidgets.QMainWindow):
+                        self.baseinstance.setCentralWidget(
+                                widget.centralWidget())
+                        self.baseinstance.setMenuBar(widget.menuBar())
+                        self.baseinstance.setStatusBar(widget.statusBar())
+                    else:
+                        self.baseinstance.setLayout(widget.layout())
+
                 # Workaround for PySide 1.0.9, see issue #208
                 widget.parentWidget()
 
@@ -942,7 +959,7 @@ def _loadUi(uifile, baseinstance=None):
                 if parent is None and self.baseinstance:
                     # Supposed to create the top-level widget,
                     # return the base instance instead
-                    return self.baseinstance
+                    parent = self.baseinstance
 
                 # For some reason, Line is not in the list of available
                 # widgets, but works fine, so we have to special case it here.

--- a/Qt.py
+++ b/Qt.py
@@ -928,21 +928,14 @@ def _loadUi(uifile, baseinstance=None):
                     self, uifile, *args, **kwargs)
 
                 if self.baseinstance:
-
-                    # copy over all the widgets and layouts from attributes
-                    for member in dir(widget):
-                        value = getattr(widget, member)
-                        if isinstance(value, Qt.QtCore.QObject):
-                            setattr(self.baseinstance, member, value)
-
-                    # poach main layouts and widgets
-                    if isinstance(widget, Qt.QtWidgets.QMainWindow):
-                        self.baseinstance.setCentralWidget(
-                                widget.centralWidget())
-                        self.baseinstance.setMenuBar(widget.menuBar())
-                        self.baseinstance.setStatusBar(widget.statusBar())
-                    else:
-                        self.baseinstance.setLayout(widget.layout())
+                    # correct geometry on show
+                    parent = self.baseinstance.parentWidget()
+                    if parent and hasattr(parent, 'geometry'):
+                        geo = self.baseinstance.geometry()
+                        pgeo = parent.geometry()
+                        self.baseinstance.move(
+                                pgeo.x() + pgeo.width()/2 - geo.width()/2,
+                                pgeo.y() + pgeo.height()/2 - geo.height()/2)
 
                 # Workaround for PySide 1.0.9, see issue #208
                 widget.parentWidget()
@@ -959,7 +952,7 @@ def _loadUi(uifile, baseinstance=None):
                 if parent is None and self.baseinstance:
                     # Supposed to create the top-level widget,
                     # return the base instance instead
-                    parent = self.baseinstance
+                    return self.baseinstance
 
                 # For some reason, Line is not in the list of available
                 # widgets, but works fine, so we have to special case it here.


### PR DESCRIPTION
This is an attempt to fix #323. Where a UI loaded in `PySide` from a `.ui` file does not show up at the top of the parent widget as expected.

This solution creates a new widget as a child or the "base instance" and then uses the new widgets layout or central widget on the base instance.

 