### PR TITLE
Add QtSiteConfig.preferred_binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,12 @@ This also covers inconsistencies between bindings. For example PyQt4's QFileDial
 
 These are the publicly facing environment variables that in one way or another affect the way Qt.py is run.
 
-| Variable             | Type  | Description
-|:---------------------|:------|:----------
-| QT_PREFERRED_BINDING | str   | Override order and content of binding to try.
-| QT_VERBOSE           | bool  | Be a little more chatty about what's going on with Qt.py
-| QT_SIP_API_HINT      | int   | Sets the preferred SIP api version that will be attempted to set.
+| Variable                  | Type  | Description
+|:--------------------------|:------|:----------
+| QT_PREFERRED_BINDING_JSON | str   | Override order and content of binding to try. This can apply per Qt.py namespace.
+| QT_PREFERRED_BINDING      | str   | Override order and content of binding to try. Used if QT_PREFERRED_BINDING_JSON does not apply.
+| QT_VERBOSE                | bool  | Be a little more chatty about what's going on with Qt.py
+| QT_SIP_API_HINT           | int   | Sets the preferred SIP api version that will be attempted to set.
 
 <br>
 
@@ -227,11 +228,30 @@ PyQt5
 Constrain available choices and order of discovery by supplying multiple values.
 
 ```bash
-# Try PyQt first and then PySide, but nothing else.
-$ export QT_PREFERRED_BINDING=PyQt:PySide
+# Try PyQt4 first and then PySide, but nothing else.
+$ export QT_PREFERRED_BINDING=PyQt4:PySide
 ```
 
 Using the OS path separator (`os.pathsep`) which is `:` on Unix systems and `;` on Windows.
+
+If you need to control the preferred choice of a specific vendored Qt.py you can use the `QT_PREFERRED_BINDING_JSON` environment variable instead.
+
+```json
+{
+    "Qt":["PyQt5"],
+    "myproject.vendor.Qt":["PyQt5"],
+    "default":["PySide2"]
+}
+```
+
+This json data forces any code that uses `import Qt` or `import myproject.vendor.Qt` to use PyQt5(`from x import Qt` etc works too, this is based on `__name__` of the Qt.py being imported). Any other imports of a Qt module will use the "default" PySide2 only. If `"default"` is not provided or a Qt.py being used does not support `QT_PREFERRED_BINDING_JSON`, `QT_PREFERRED_BINDING` will be respected.
+
+```bash
+# Try PyQt5 first and then PyQt4 for the Qt module name space.
+$ export QT_PREFERRED_BINDING_JSON="{"Qt":["PyQt5","PyQt4"]}"
+# Use PyQt4 for any other Qt module name spaces.
+$ export QT_PREFERRED_BINDING=PySide2
+```
 
 <br>
 


### PR DESCRIPTION
I need to use PyQt5 in Maya/3ds Max/Houdini, etc. It works great until we need to install a third party script that was written expecting to be using PySide/PySide2. For the most part it works, but eventually you end up with a argument order difference or something else causing the PySide2 code to error out.

This merge request allows you to easily specify the preferred binding for each individual Qt.py import based on the full module path.

I can use the alternative workflow if we decide this isn't worth adding, but it makes the developing and testing process easier if `QtSiteConfig.preferred_binding` manages things for you.

##### More details from the QtSiteConfig readme:

If you need to use both PyQt and PySide in the same application you may run into problems if you just set the QT_PREFERRED_BINDING environment variable.

For example, in Maya you set QT_PREFERRED_BINDING to PyQt5 to load your PyQt5 code. You then try to use the https://www.studiolibrary.com/ tool, it was written
expecting to only use PySide or PySide2, a reasonable assumption for a Maya tool. This causes errors when using it.

To work around this, you can make sure that your PyQt setup code imports studio library, then sets the QT_PREFERRED_BINDING env variable. This is nice if you want to be able to
reload your Qt.py class for debugging your QtSiteConfig setup as importing Qt will still use PyQt. You are not able to reload the studiolibrary vendored Qt.py. This also does not work in cases where you are unable to import the vendored Qt.py at this point. This also means that any time your users want to use a new tool, you have to add support for it.

Alternatively you can make your PyQt setup code set QT_PREFERRED_BINDING to PyQt5, import your Qt.py, and clear the QT_PREFERRED_BINDING environment variable
so when studio library is imported it will use PySide2. You would need to make sure to re-set the QT_PREFERRED_BINDING environment variable to allow you to reload your Qt.py.

If you implement the `preferred_binding(module_name, preferred_order)` function in your QtSiteConfig module, you can choose the desired behavior for each Qt.py when it is imported without any of the above drawbacks.

```python
def preferred_binding(module_name, preferred_order):
    """ If this is processing the global Qt.py import, use PyQt, otherwise
    use the default preferred_order.

    Args:
        module_name (str): The full module name of the Qt.py import.
        preferred_order (list): This list should be modified to control
            the order Qt bindings are loaded. This respects the
            QT_PREFERRED_BINDING environment variable.
    """
    if module_name == 'Qt':
        # The Qt module was imported directly from a path in sys.path
        # I want PyQt5 to be the first package loaded.
        preferred_order.insert(0, 'PyQt5')
    # The Qt module was imported from a vendored package for example
    # `mypackage.vendor.Qt` Don't modify the order.
```