### PR TITLE
Update error message for failure to parse preferred JSON

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -1664,7 +1664,11 @@ def _none():
 
 def _log(text):
     if QT_VERBOSE:
-        sys.stdout.write(text + "\n")
+        sys.stdout.write("Qt.py [info]: %s\n" % text)
+
+
+def _warn(text):
+    sys.stderr.write("Qt.py [warning]: %s\n" % text)
 
 
 def _convert(lines):
@@ -1796,10 +1800,11 @@ def _install():
         #   {"mylibrary.vendor.Qt": ["PySide2"], "default":["PyQt5","PyQt4"]}
         try:
             preferred_bindings = json.loads(QT_PREFERRED_BINDING_JSON)
-        except ValueError as e:
+        except ValueError:
             # Python 2 raises ValueError, Python 3 raises json.JSONDecodeError
             # a subclass of ValueError
-            _log("JSONDecodeError: {}".format(e))
+            _warn("Failed to parse QT_PREFERRED_BINDING_JSON='%s'" % QT_PREFERRED_BINDING_JSON)
+            _warn("Falling back to default preferred order")
         else:
             preferred_order = preferred_bindings.get(__name__)
             # If no matching binding was used, optionally apply a default.

--- a/Qt.py
+++ b/Qt.py
@@ -1803,7 +1803,8 @@ def _install():
         except ValueError:
             # Python 2 raises ValueError, Python 3 raises json.JSONDecodeError
             # a subclass of ValueError
-            _warn("Failed to parse QT_PREFERRED_BINDING_JSON='%s'" % QT_PREFERRED_BINDING_JSON)
+            _warn("Failed to parse QT_PREFERRED_BINDING_JSON='%s'"
+                   % QT_PREFERRED_BINDING_JSON)
             _warn("Falling back to default preferred order")
         else:
             preferred_order = preferred_bindings.get(__name__)

--- a/Qt.py
+++ b/Qt.py
@@ -1804,7 +1804,7 @@ def _install():
             # Python 2 raises ValueError, Python 3 raises json.JSONDecodeError
             # a subclass of ValueError
             _warn("Failed to parse QT_PREFERRED_BINDING_JSON='%s'"
-                   % QT_PREFERRED_BINDING_JSON)
+                  % QT_PREFERRED_BINDING_JSON)
             _warn("Falling back to default preferred order")
         else:
             preferred_order = preferred_bindings.get(__name__)

--- a/Qt.py
+++ b/Qt.py
@@ -45,7 +45,7 @@ import importlib
 import json
 
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 
 # Enable support for `from Qt import *`
 __all__ = []

--- a/tests.py
+++ b/tests.py
@@ -581,6 +581,7 @@ def test_vendoring():
     #
     # Test invalid json data
     #
+    env = os.environ.copy()
     env["QT_PREFERRED_BINDING_JSON"] = '{"Qt":["PyQt5","PyQt4"],}'
 
     cmd = "import myproject.vendor.Qt;"
@@ -614,7 +615,6 @@ def test_vendoring():
 
     # Check QT_PREFERRED_BINDING_JSON works as expected
     print("Testing QT_PREFERRED_BINDING_JSON is respected..")
-    env = os.environ.copy()
     cmd = "import myproject.vendor.Qt;"
     # Check that the "None" binding was set for `import myproject.vendor.Qt`
     cmd += "assert myproject.vendor.Qt.__binding__ == 'None', 'vendor';"
@@ -624,6 +624,7 @@ def test_vendoring():
     cmd += "assert Qt.__binding__ != 'None', 'Qt'"
 
     # If the module name is "Qt" use PyQt5 or PyQt4, otherwise use None binding
+    env = os.environ.copy()
     env["QT_PREFERRED_BINDING_JSON"] = json.dumps(
         {
             "Qt": ["PyQt5", "PyQt4"],

--- a/tests.py
+++ b/tests.py
@@ -597,7 +597,7 @@ def test_vendoring():
     popen = subprocess.Popen(
         [sys.executable, "-c", cmd],
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         cwd=self.tempdir,
         env=env
     )

--- a/tests.py
+++ b/tests.py
@@ -8,6 +8,7 @@ import tempfile
 import subprocess
 import contextlib
 import datetime
+import json
 
 # Third-party dependency
 import six

--- a/tests.py
+++ b/tests.py
@@ -605,12 +605,12 @@ def test_vendoring():
     # Check that the python subprocess exited cleanly.
     if popen.returncode != 0:
         print(out)
-        msg = 'A exception was raised'
+        msg = "An exception was raised"
         assert popen.returncode == 0, msg
 
     # Check that nothing was logged if not in verbose mode.
-    error_check = b"JSONDecodeError: Expecting property name"
-    assert error_check not in out, out
+    error_check = "Qt.py [warning]:"
+    assert not err.startswith(error_check), err
 
     print("Testing invalid QT_PREFERRED_BINDING_JSON shows in verbose..")
     # We should get debug info if using verbose mode
@@ -638,8 +638,8 @@ def test_vendoring():
     print('err ------------------')
     print(err)
 
-    # Check that a useful message was logged in verbose mode
-    assert error_check in out, out
+    # Check that a warning was logged
+    assert err.startswith(error_check), err
 
     # Check QT_PREFERRED_BINDING_JSON works as expected
     print("Testing QT_PREFERRED_BINDING_JSON is respected..")


### PR DESCRIPTION
Qt.py can print an error on import that looks like..

```cmd
> $ python -c "import Qt"
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

But it doesn't tell you why, and if you aren't familiar with the new `QT_PREFERRED_BINDING_JSON` variable then I expect we'll see issues pop up here.

I've changed that message to:

```cmd
> $ python -c "import Qt"
Qt.py [warning]: Failed to parse QT_PREFERRED_BINDING_JSON='blabla;bla'
Qt.py [warning]: Falling back to default preferred order
```