### PR TITLE
Log warnings for unexpected ImportError of submodules instead of hiding

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -45,7 +45,7 @@ import importlib
 import json
 
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 
 # Enable support for `from Qt import *`
 __all__ = []

--- a/Qt.py
+++ b/Qt.py
@@ -1253,6 +1253,12 @@ def _setup(module, extras):
 
     Qt.__binding__ = module.__name__
 
+    def _warn_import_error(exc):
+        msg = str(exc)
+        if "No module named" in msg:
+            return
+        _warn("ImportError: %s" % msg)
+
     for name in list(_common_members) + extras:
         try:
             submodule = _import_sub_module(
@@ -1667,22 +1673,6 @@ def _none():
 def _log(text):
     if QT_VERBOSE:
         sys.stdout.write("Qt.py [info]: %s\n" % text)
-
-
-def _warn_import_error(exc):
-    """Log import errors matching unexpected criteria
-
-    Arguments:
-        exc (Exception)
-    """
-    if not exc or not isinstance(exc, ImportError):
-        return
-
-    msg = str(exc)
-    if "No module named" in msg:
-        return
-
-    _warn("ImportError: %s" % msg)
 
 
 def _warn(text):

--- a/Qt.py
+++ b/Qt.py
@@ -43,7 +43,6 @@ import types
 import shutil
 import importlib
 import json
-import warnings
 
 
 __version__ = "1.2.5"


### PR DESCRIPTION
We recently had an issue importing PySide2 that required a bit of debugging to ultimately figure out the cause. The failure to the user looked like `ImportError: No module named QtCore` or `'module' object has no attribute QtGui`, depending on which version of Qt.py one is running. 

The circumstances of the error are as follows:
User observes command working fine locally with PySide2 within Nuke, and sends it to the render farm.
Command fails on the render farm, running outside of Nuke, looking as if PySide2 is not available in the environment.
As it turns out, the cause of the failure is that Nuke's libraries were being picked up first in the `LD_LIBRARY_PATH` on the farm and conflicting with the external PySide2 causing an `ImportError`:

```
ImportError: /path/to/PySide2/QtCore.so: symbol _ZN23QOperatingSystemVersion13MacOSCatalinaE version Qt_5 not defined in file libQt5Core.so.5 with link time reference 
```

But this error is being masked by the `_setup()` failing on the first attempt and hiding the exception, then trying again with a second import approach. If we could see this error it would have made it a lot more obvious that it was seeing PySide2 but conflicting with the Qt libraries. 

This patch logs unexpected `ImportErrors` of just the submodules, as a warning. So this means `PySide2` would first succeed as being imported and available, but then some kind of problem happens with its submodules.

```
Qt.py [warning]: ImportError: /path/to/PySide2/QtCore.so: symbol _ZN23QOperatingSystemVersion13MacOSCatalinaE version Qt_5 not defined in file libQt5Core.so.5 with link time reference
...
Traceback ...
AttributeError: 'module' object has no attribute 'QtCore' 
```

Open to feedback on different ways to capture or present this.