### PR TITLE
PyQt enums patch

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -37,6 +37,7 @@ LICENSE
 
 """
 
+import inspect
 import os
 import sys
 import types
@@ -1813,7 +1814,7 @@ def _pyqt_enums_patch():
     }
 
     known_enums = set()
-    for attr_name, enum_class in qt_attrs.items():
+    for enum_class in qt_attrs.values():
         if inspect.isclass(enum_class) and issubclass(enum_class, int):
             known_enums.add(enum_class)
             enum_class.values = {}

--- a/tests.py
+++ b/tests.py
@@ -1197,4 +1197,6 @@ if binding("PyQt4") or binding("PyQt5"):
                 cls_value = cls_values[attr_name]
                 assert value == cls_values[attr_name], (
                     "({0}) {1!r} != {2!r} ({3}[{4}])".format(
-                    attr_path, value, cls_value, values_path, attr_name))
+                        attr_path, value, cls_value, values_path, attr_name
+                    )
+                )

--- a/tests.py
+++ b/tests.py
@@ -1162,16 +1162,16 @@ if binding("PyQt4") or binding("PyQt5"):
 
     def test_pyqt_enums():
         """Check some known enums/flags mappings."""
-        from Qt import QtCore
+        from Qt import QtCompat
 
         class_attributes = {  # Version agnostic flags and enums
             "CheckState": ["Checked", "Unchecked", "PartiallyChecked"],
             "Orientation": ["Horizontal", "Vertical"],
         }
         for class_name, attributes in class_attributes.items():
-            qt_class = getattr(QtCore.Qt, class_name)
+            qt_class = getattr(QtCompat, class_name)
 
-            values_path = "QtCore.Qt.%s.%s" % (class_name, "values")
+            values_path = "QtCompat.%s.%s" % (class_name, "values")
             assert hasattr(qt_class, "values"), (
                 "%s should exist, but is missing" % values_path)
 
@@ -1181,7 +1181,7 @@ if binding("PyQt4") or binding("PyQt5"):
                 % (values_path, cls_values))
 
             for attr_name in attributes:
-                attr_path = "QtCore.Qt.%s.%s" % (class_name, attr_name)
+                attr_path = "QtCompat.%s.%s" % (class_name, attr_name)
 
                 assert hasattr(qt_class, attr_name), (
                     "%s should exist, but is missing" % attr_path)

--- a/tests.py
+++ b/tests.py
@@ -1159,3 +1159,42 @@ if binding("PyQt4") or binding("PyQt5"):
         assert Qt.__binding__ == "PyQt4", (
             "PyQt4 should have been picked, "
             "instead got %s" % Qt.__binding__)
+
+    def test_pyqt_enums():
+        """Check some known enums/flags mappings."""
+        from Qt import QtCore
+
+        class_attributes = {  # Version agnostic flags and enums
+            "CheckState": ["Checked", "Unchecked", "PartiallyChecked"],
+            "Orientation": ["Horizontal", "Vertical"],
+        }
+        for class_name, attributes in class_attributes.items():
+            qt_class = getattr(QtCore.Qt, class_name)
+
+            values_path = "QtCore.Qt.{0}.{1}".format(class_name, "values")
+            assert hasattr(qt_class, "values"), (
+                "{0} should exist, but is missing".format(values_path))
+
+            cls_values = getattr(qt_class, "values", None)
+            assert cls_values and isinstance(cls_values, dict), (
+                "{0} should be a non-empty dictionary, "
+                "not {1}".format(values_path, cls_values))
+
+            for attr_name in attributes:
+                attr_path = "QtCore.Qt.{0}.{1}".format(class_name, attr_name)
+
+                assert hasattr(qt_class, attr_name), (
+                    "{0} should exist, but is missing".format(attr_path))
+
+                value = getattr(qt_class, attr_name, None)
+                assert value is not None, (
+                    "{0} shouldn't be None".format(attr_path))
+
+                assert attr_name in cls_values, (
+                    "{0} key should exist in {1} "
+                    "dict".format(attr_name, values_path))
+
+                cls_value = cls_values[attr_name]
+                assert value == cls_values[attr_name], (
+                    "({0}) {1!r} != {2!r} ({3}[{4}])".format(
+                    attr_path, value, cls_value, values_path, attr_name))

--- a/tests.py
+++ b/tests.py
@@ -1171,32 +1171,30 @@ if binding("PyQt4") or binding("PyQt5"):
         for class_name, attributes in class_attributes.items():
             qt_class = getattr(QtCore.Qt, class_name)
 
-            values_path = "QtCore.Qt.{0}.{1}".format(class_name, "values")
+            values_path = "QtCore.Qt.%s.%s" % (class_name, "values")
             assert hasattr(qt_class, "values"), (
-                "{0} should exist, but is missing".format(values_path))
+                "%s should exist, but is missing" % values_path)
 
             cls_values = getattr(qt_class, "values", None)
             assert cls_values and isinstance(cls_values, dict), (
-                "{0} should be a non-empty dictionary, "
-                "not {1}".format(values_path, cls_values))
+                "%s should be a non-empty dictionary, not %s"
+                % (values_path, cls_values))
 
             for attr_name in attributes:
-                attr_path = "QtCore.Qt.{0}.{1}".format(class_name, attr_name)
+                attr_path = "QtCore.Qt.%s.%s" % (class_name, attr_name)
 
                 assert hasattr(qt_class, attr_name), (
-                    "{0} should exist, but is missing".format(attr_path))
+                    "%s should exist, but is missing" % attr_path)
 
                 value = getattr(qt_class, attr_name, None)
-                assert value is not None, (
-                    "{0} shouldn't be None".format(attr_path))
+                assert value is not None, "%s shouldn't be None" % attr_path
 
                 assert attr_name in cls_values, (
-                    "{0} key should exist in {1} "
-                    "dict".format(attr_name, values_path))
+                    "%s key should exist in %s dict" %
+                    (attr_name, values_path))
 
                 cls_value = cls_values[attr_name]
                 assert value == cls_values[attr_name], (
-                    "({0}) {1!r} != {2!r} ({3}[{4}])".format(
-                        attr_path, value, cls_value, values_path, attr_name
-                    )
+                    "(%s) %r != %r (%s[%s])" %
+                    (attr_path, value, cls_value, values_path, attr_name)
                 )


### PR DESCRIPTION
Patch `PyQt*` Qt namespace enums to behave like `PySide*`.

i.e. Fixes :negative_squared_cross_mark:  in `QtCore.Qt`
Attributes | `PyQt*` | `PySide*`
---|---|---
`Qt.Checked` value | :heavy_check_mark:  | :heavy_check_mark: 
`Qt.CheckState` class   | :heavy_check_mark:  | :heavy_check_mark: 
`Qt.CheckState.Checked` value | :negative_squared_cross_mark:  | :heavy_check_mark: 
`Qt.CheckState.values` dict | :negative_squared_cross_mark:  | :heavy_check_mark: 

**UPDATE** Clarification: Above is just 1 example, the intention is to patch for all flags/enums in the [Qt Namespace](https://doc.qt.io/qt-5/qt.html)

Would this fall under a similar re-name/re-expose `pyqtSignal` as `Signal`? Just curious if this will actually fall under the umbrella of [No wrappers](https://github.com/mottosso/Qt.py/blob/8a8953bc672b75a157a6c2a9b49e48985bb3e8a7/CONTRIBUTING.md#no-wrappers)
