### PR TITLE
Fixed vendorised copies of Qt.py clashing

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -1909,7 +1909,7 @@ def _install():
             setattr(our_submodule, member, placeholder)
 
     # Enable direct import of QtCompat
-    sys.modules['Qt.QtCompat'] = Qt.QtCompat
+    sys.modules[__name__ + ".QtCompat"] = Qt.QtCompat
 
     # Backwards compatibility
     if hasattr(Qt.QtCompat, 'loadUi'):

--- a/Qt.py
+++ b/Qt.py
@@ -45,7 +45,7 @@ import importlib
 import json
 
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 # Enable support for `from Qt import *`
 __all__ = []


### PR DESCRIPTION
We are using a tool that vendorises Qt.py (https://github.com/krathjen/studiolibrary). But two copies of Qt.py currently write to the same location in sys.modules, meaning that they can clash with each other.
This change follows other usage of sys.modules in Qt.py and writes to the module location of the current instance of Qt.py, rather than to the global location.