### PR TITLE
Unicode encoding in import errors - Fix for issue #346

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -1260,7 +1260,9 @@ def _setup(module, extras):
     Qt.__binding__ = module.__name__
 
     def _warn_import_error(exc, module):
-        if sys.version_info < (3, 0):
+        if sys.version_info > (3, 0):
+            unicode = str
+        else:
             if isinstance(exc, unicode):
                 exc = exc.encode('ascii', 'replace')
         msg = str(exc)

--- a/Qt.py
+++ b/Qt.py
@@ -1263,8 +1263,11 @@ def _setup(module, extras):
         if sys.version_info > (3, 0):
             unicode = str
         else:
-            if isinstance(exc, unicode):
-                exc = exc.encode('ascii', 'replace')
+            try:
+                if isinstance(exc, unicode):
+                    exc = exc.encode('ascii', 'replace')
+            except (UnboundLocalError, NameError):
+                pass
         msg = str(exc)
         if "No module named" in msg:
             return

--- a/Qt.py
+++ b/Qt.py
@@ -45,7 +45,7 @@ import importlib
 import json
 
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 # Enable support for `from Qt import *`
 __all__ = []


### PR DESCRIPTION
If Python 2, and import error message is unicode, encode as ascii before casting to string to avoid UnicodeDecodeError.

Fix for #346 

Typical example of error message that triggers a UnicodeDecodeError:

> DLL load failed : le module spécifié est introuvable.

Typical use case where this happens:

> French Windows language and trying to use Qt.py in application with Python 2 and unicode strings.

Isolated behavior:

```python
import sys
text = str(u"DLL load failed : le module spécifié est introuvable.".encode('ascii', 'replace'))
>> b'DLL load failed : le module sp?cifi? est introuvable.'
```