### PR TITLE
Bugfix for #357

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -1260,18 +1260,13 @@ def _setup(module, extras):
     Qt.__binding__ = module.__name__
 
     def _warn_import_error(exc, module):
-        if sys.version_info > (3, 0):
-            unicode = str
-        else:
-            try:
-                if isinstance(exc, unicode):
-                    exc = exc.encode('ascii', 'replace')
-            except (UnboundLocalError, NameError):
-                pass
+        if sys.version_info < (3, 0):
+            if type(exc).__name__ == 'unicode':
+                exc = exc.encode('ascii', 'replace')
         msg = str(exc)
         if "No module named" in msg:
             return
-        _warn("ImportError(%s): %s" % (module, msg))
+        _warn("ImportError: %s" % msg)
 
     for name in list(_common_members) + extras:
         try:

--- a/Qt.py
+++ b/Qt.py
@@ -1266,7 +1266,7 @@ def _setup(module, extras):
         msg = str(exc)
         if "No module named" in msg:
             return
-        _warn("ImportError: %s" % msg)
+        _warn("ImportError(%s): %s" % (module, msg))
 
     for name in list(_common_members) + extras:
         try:

--- a/Qt.py
+++ b/Qt.py
@@ -1254,19 +1254,20 @@ def _import_sub_module(module, name):
     return module
 
 
+def _warn_import_error(exc, module):
+    if sys.version_info < (3, 0):
+        if type(exc).__name__ == 'unicode':
+            exc = exc.encode('ascii', 'replace')
+    msg = str(exc)
+    if "No module named" in msg:
+        return
+    _warn("ImportError(%s): %s" % (module, msg))
+
+
 def _setup(module, extras):
     """Install common submodules"""
 
     Qt.__binding__ = module.__name__
-
-    def _warn_import_error(exc, module):
-        if sys.version_info < (3, 0):
-            if type(exc).__name__ == 'unicode':
-                exc = exc.encode('ascii', 'replace')
-        msg = str(exc)
-        if "No module named" in msg:
-            return
-        _warn("ImportError(%s): %s" % (module, msg))
 
     for name in list(_common_members) + extras:
         try:

--- a/Qt.py
+++ b/Qt.py
@@ -1255,10 +1255,11 @@ def _import_sub_module(module, name):
 
 
 def _warn_import_error(exc, module):
-    if sys.version_info < (3, 0):
-        if type(exc).__name__ == 'unicode':
-            exc = exc.encode('ascii', 'replace')
-    msg = str(exc)
+    try:
+        msg = str(exc)
+    except UnicodeEncodeError:
+        # args[0] is the message of the error
+        msg = str(exc.args[0].encode('ascii', 'replace'))
     if "No module named" in msg:
         return
     _warn("ImportError(%s): %s" % (module, msg))
@@ -1663,7 +1664,7 @@ def _pyqt4():
     }
     _build_compatibility_members('PyQt4', decorators)
 
-
+ImportError.
 def _none():
     """Internal option (used in installer)"""
 

--- a/Qt.py
+++ b/Qt.py
@@ -1664,7 +1664,7 @@ def _pyqt4():
     }
     _build_compatibility_members('PyQt4', decorators)
 
-ImportError.
+
 def _none():
     """Internal option (used in installer)"""
 

--- a/tests.py
+++ b/tests.py
@@ -891,6 +891,17 @@ def test_missing():
     )
 
 
+def test_unicode_error_messages():
+    """Test if unicode error messages with non-ascii characters throw the error reporter off"""
+    import Qt
+    message = u"DLL load failed : le module spécifié est introuvable."
+    module = Qt.__binding__
+
+    with captured_output() as out:
+        Qt._warn_import_error(exc=message, module=module)
+        assert "DLL load failed" in out.getvalue()
+
+
 if sys.version_info < (3, 5):
     # PySide is not available for Python > 3.4
     # Shiboken(1) doesn't support Python 3.5

--- a/tests.py
+++ b/tests.py
@@ -900,8 +900,9 @@ def test_unicode_error_messages():
     module = Qt.__binding__
 
     with captured_output() as out:
+        stdout, stderr = out
         Qt._warn_import_error(exc=message, module=module)
-        assert "DLL load failed" in out.getvalue()
+        assert "DLL load failed" in stderr.getvalue()
 
 
 if sys.version_info < (3, 5):

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 """Tests that run once"""
 import io
 import os

--- a/tests.py
+++ b/tests.py
@@ -892,7 +892,8 @@ def test_missing():
 
 
 def test_unicode_error_messages():
-    """Test if unicode error messages with non-ascii characters throw the error reporter off"""
+    """Test if unicode error messages with non-ascii characters
+    throw the error reporter off"""
     import Qt
     message = u"DLL load failed : le module spécifié est introuvable."
     module = Qt.__binding__


### PR DESCRIPTION
In #357 I proposed a solution to capture non-ascii characters in python 2 unicode strings before passing them to str().

An oversight meant that Python 2 was still unable to run the code. I propose the bugfix in this code and made the small test case to prove that the code now works in Python 2 and Python 3 and will go through all code tests.

```python
# coding=utf-8
# works in python 2 and python 3
import sys


def _warn_import_error(exc):
    if sys.version_info < (3, 0):
        if type(exc).__name__ == 'unicode':
            exc = exc.encode('ascii', 'replace')
    msg = str(exc)
    if "No module named" in msg:
        return
    _warn("ImportError(%s): %s" % (module, msg))


def _warn(text):
    sys.stderr.write("Qt.py [warning]: %s\n" % text)


message = u"DLL load failed : le module spécifié est introuvable."
_warn_import_error(message)
```

Bugfix for cast to ascii
Python logic: in previous version, the declaration of unicode = str in the Python 3 exclusive path made the Python 2 code fail, as unicode was now seen as an undeclared variable (as it had been declared in the Python 3 code, so Python assumes it is no longer the build-in type).

This version uses string comparison to work around the issue of the type.__name__, which seems to be the only way to work around this issue.