### PR TITLE
Actual fix for #346 - unroll of #357

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -1260,18 +1260,13 @@ def _setup(module, extras):
     Qt.__binding__ = module.__name__
 
     def _warn_import_error(exc, module):
-        if sys.version_info > (3, 0):
-            unicode = str
-        else:
-            try:
-                if isinstance(exc, unicode):
-                    exc = exc.encode('ascii', 'replace')
-            except (UnboundLocalError, NameError):
-                pass
+        if sys.version_info < (3, 0):
+            if type(exc).__name__ == 'unicode':
+                exc = exc.encode('ascii', 'replace')
         msg = str(exc)
         if "No module named" in msg:
             return
-        _warn("ImportError(%s): %s" % (module, msg))
+        _warn("ImportError: %s" % msg)
 
     for name in list(_common_members) + extras:
         try:

--- a/Qt.py
+++ b/Qt.py
@@ -1254,21 +1254,14 @@ def _import_sub_module(module, name):
     return module
 
 
-def _warn_import_error(exc, module):
-    try:
-        msg = str(exc)
-    except UnicodeEncodeError:
-        # args[0] is the message of the error
-        msg = str(exc.args[0].encode('ascii', 'replace'))
-    if "No module named" in msg:
-        return
-    _warn("ImportError(%s): %s" % (module, msg))
-
-
 def _setup(module, extras):
     """Install common submodules"""
 
     Qt.__binding__ = module.__name__
+
+    def _warn_import_error(exc, module):
+        msg = str(exc)
+        _warn("ImportError(%s): %s" % (module, msg))
 
     for name in list(_common_members) + extras:
         try:
@@ -1687,7 +1680,10 @@ def _log(text):
 
 
 def _warn(text):
-    sys.stderr.write("Qt.py [warning]: %s\n" % text)
+	try:
+		sys.stderr.write("Qt.py [warning]: %s\n" % text)
+	except UnicodeDecodeError:
+		sys.stderr.write("Qt.py [warning]: %s\n" % text.decode("utf-8", "replace"))
 
 
 def _convert(lines):

--- a/Qt.py
+++ b/Qt.py
@@ -1266,7 +1266,7 @@ def _setup(module, extras):
         msg = str(exc)
         if "No module named" in msg:
             return
-        _warn("ImportError: %s" % msg)
+        _warn("ImportError(%s): %s" % (module, msg))
 
     for name in list(_common_members) + extras:
         try:

--- a/Qt.py
+++ b/Qt.py
@@ -1254,19 +1254,20 @@ def _import_sub_module(module, name):
     return module
 
 
+def _warn_import_error(exc, module):
+    if sys.version_info < (3, 0):
+        if type(exc).__name__ == 'unicode':
+            exc = exc.encode('ascii', 'replace')
+    msg = str(exc)
+    if "No module named" in msg:
+        return
+    _warn("ImportError(%s): %s" % (module, msg))
+
+
 def _setup(module, extras):
     """Install common submodules"""
 
     Qt.__binding__ = module.__name__
-
-    def _warn_import_error(exc, module):
-        if sys.version_info < (3, 0):
-            if type(exc).__name__ == 'unicode':
-                exc = exc.encode('ascii', 'replace')
-        msg = str(exc)
-        if "No module named" in msg:
-            return
-        _warn("ImportError(%s): %s" % (module, msg))
 
     for name in list(_common_members) + extras:
         try:

--- a/Qt.py
+++ b/Qt.py
@@ -1261,6 +1261,8 @@ def _setup(module, extras):
 
     def _warn_import_error(exc, module):
         msg = str(exc)
+        if "No module named" in msg:
+            return
         _warn("ImportError(%s): %s" % (module, msg))
 
     for name in list(_common_members) + extras:
@@ -1680,10 +1682,12 @@ def _log(text):
 
 
 def _warn(text):
-	try:
-		sys.stderr.write("Qt.py [warning]: %s\n" % text)
-	except UnicodeDecodeError:
-		sys.stderr.write("Qt.py [warning]: %s\n" % text.decode("utf-8", "replace"))
+    try:
+        sys.stderr.write("Qt.py [warning]: %s\n" % text)
+    except UnicodeDecodeError:
+        import locale
+        encoding = locale.getpreferredencoding()
+        sys.stderr.write("Qt.py [warning]: %s\n" % text.decode(encoding))
 
 
 def _convert(lines):

--- a/Qt.py
+++ b/Qt.py
@@ -1255,10 +1255,11 @@ def _import_sub_module(module, name):
 
 
 def _warn_import_error(exc, module):
-    if sys.version_info < (3, 0):
-        if type(exc).__name__ == 'unicode':
-            exc = exc.encode('ascii', 'replace')
-    msg = str(exc)
+    try:
+        msg = str(exc)
+    except UnicodeEncodeError:
+        # args[0] is the message of the error
+        msg = str(exc.args[0].encode('ascii', 'replace'))
     if "No module named" in msg:
         return
     _warn("ImportError(%s): %s" % (module, msg))
@@ -1663,7 +1664,7 @@ def _pyqt4():
     }
     _build_compatibility_members('PyQt4', decorators)
 
-
+ImportError.
 def _none():
     """Internal option (used in installer)"""
 

--- a/Qt.py
+++ b/Qt.py
@@ -1664,7 +1664,7 @@ def _pyqt4():
     }
     _build_compatibility_members('PyQt4', decorators)
 
-ImportError.
+
 def _none():
     """Internal option (used in installer)"""
 

--- a/tests.py
+++ b/tests.py
@@ -898,7 +898,6 @@ def test_unicode_error_messages():
     import Qt
     unicode_message = u"DLL load failed : le module spécifié est introuvable."
     str_message = "DLL load failed : le module"
-    module = Qt.__binding__
 
     with captured_output() as out:
         stdout, stderr = out

--- a/tests.py
+++ b/tests.py
@@ -891,6 +891,17 @@ def test_missing():
     )
 
 
+def test_unicode_error_messages():
+    """Test if unicode error messages with non-ascii characters throw the error reporter off"""
+    import Qt
+    message = u"DLL load failed : le module spécifié est introuvable."
+    module = Qt.__binding__
+
+    with captured_output() as out:
+        Qt._warn_import_error(exc=message, module=module)
+        assert "DLL load failed" in out.getvalue()
+
+
 if sys.version_info < (3, 5):
     # PySide is not available for Python > 3.4
     # Shiboken(1) doesn't support Python 3.5

--- a/tests.py
+++ b/tests.py
@@ -901,7 +901,7 @@ def test_unicode_error_messages():
 
     with captured_output() as out:
         stdout, stderr = out
-        Qt._warn_import_error(exc=message, module=module)
+        Qt._warn(text=message)
         assert "DLL load failed" in stderr.getvalue()
 
 

--- a/tests.py
+++ b/tests.py
@@ -900,8 +900,9 @@ def test_unicode_error_messages():
     module = Qt.__binding__
 
     with captured_output() as out:
+        stdout, stderr = out
         Qt._warn_import_error(exc=message, module=module)
-        assert "DLL load failed" in out.getvalue()
+        assert "DLL load failed" in stderr.getvalue()
 
 
 if sys.version_info < (3, 5):

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 """Tests that run once"""
 import io
 import os

--- a/tests.py
+++ b/tests.py
@@ -892,7 +892,8 @@ def test_missing():
 
 
 def test_unicode_error_messages():
-    """Test if unicode error messages with non-ascii characters throw the error reporter off"""
+    """Test if unicode error messages with non-ascii characters
+    throw the error reporter off"""
     import Qt
     message = u"DLL load failed : le module spécifié est introuvable."
     module = Qt.__binding__

--- a/tests.py
+++ b/tests.py
@@ -896,13 +896,14 @@ def test_unicode_error_messages():
     """Test if unicode error messages with non-ascii characters
     throw the error reporter off"""
     import Qt
-    message = u"DLL load failed : le module spécifié est introuvable."
+    unicode_message = u"DLL load failed : le module spécifié est introuvable."
+    str_message = "DLL load failed : le module"
     module = Qt.__binding__
 
     with captured_output() as out:
         stdout, stderr = out
-        Qt._warn(text=message)
-        assert "DLL load failed" in stderr.getvalue()
+        Qt._warn(text=unicode_message)
+        assert str_message in stderr.getvalue()
 
 
 if sys.version_info < (3, 5):


### PR DESCRIPTION
After much back and forth trying to pin point the issue for one of our French speaking users, I got around getting a French Windows PC and rolled back through all the changes made to fix #346 .

This resets `_setup` and `_warn_import_errors` which I thought were the original culprits. However, the issue is specific to how 3Ds Max (and other Autodesk DCCs) use unicode strings in stdout.

This change moves catching the unicode error to `_warn` and encodes the message using the preferred locale, resulting in more readable code and a more readable error message.

I updated the test to test this without the need for a full setup.