### PR TITLE
Minor additions (QScreen, QGLPixelBuffer)

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -45,7 +45,7 @@ import importlib
 import json
 
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 
 # Enable support for `from Qt import *`
 __all__ = []
@@ -288,6 +288,7 @@ _common_members = {
         "QRegion",
         "QResizeEvent",
         "QSessionManager",
+        "QScreen",
         "QShortcutEvent",
         "QShowEvent",
         "QStandardItem",
@@ -396,7 +397,8 @@ _common_members = {
         "QGL",
         "QGLContext",
         "QGLFormat",
-        "QGLWidget"
+        "QGLWidget",
+        "QGLPixelBuffer"
     ],
     "QtPrintSupport": [
         "QAbstractPrintDialog",


### PR DESCRIPTION
Hey, we have these two additions in our internal fork of Qt.py and would like to see if they can make it into the official repo. We use them internally with Python 2 PySide and PySide2 (Autodesk Maya/Motionbuilder/3Ds Max) and Python 3 PySide 2 (Autodesk, General tools).

- Added QtGui.QScreen and QtOpenGL.QGLPixelBuffer
- Suggesting to bump patch version to 1.3.7