### PR TITLE
Remove assert Statement from QtCompat.isValid()

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -812,9 +812,6 @@ def _isvalid(object):
         object (QObject): QObject to check the validity of.
 
     """
-
-    assert isinstance(object, Qt.QtCore.QObject)
-
     if hasattr(Qt, "_shiboken2"):
         return getattr(Qt, "_shiboken2").isValid(object)
 

--- a/tests.py
+++ b/tests.py
@@ -1051,11 +1051,24 @@ if sys.version_info < (3, 5):
 
     def test_isValid():
         """.isValid and .delete work in all bindings"""
-        from Qt import QtCompat, QtCore
-        obj = QtCore.QObject()
-        assert QtCompat.isValid(obj)
-        QtCompat.delete(obj)
-        assert not QtCompat.isValid(obj)
+        from Qt import QtCompat, QtCore, QtWidgets
+
+        app = QtWidgets.QApplication(sys.argv)
+
+        try:
+            obj = QtCore.QObject()
+            assert QtCompat.isValid(obj)
+            QtCompat.delete(obj)
+            assert not QtCompat.isValid(obj)
+
+            # Graphics Item
+            item = QtWidgets.QGraphicsItemGroup()
+            assert QtCompat.isValid(item)
+            QtCompat.delete(item)
+            assert not QtCompat.isValid(item)
+
+        finally:
+            app.exit()
 
 
 if binding("PyQt4"):


### PR DESCRIPTION
In reference to issue #369: 

- Remove `assert` statement from `QtCompat.isValid()` to ensure the function is available for any objects (not just ones that inherit from `QObject`).
- Update the `test_isValid()` unittest.