### PR TITLE
fix translate arguments

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -831,23 +831,31 @@ def _translate(context, sourceText, *args):
     # The first argument is disambiguation[str]
     # The last argument is n[int]
     # The middle argument can be encoding[QtCore.QCoreApplication.Encoding]
+    try:
+        app = getattr(Qt.QtCore, "QCoreApplication")
+    except AttributeError:
+        raise NotImplementedError("Missing QCoreApplication implementation for {}".format(Qt.__binding__))
+
+    def get_arg(index):
+        try:
+            return args[index]
+        except IndexError:
+            pass
+
+    n = -1
+    encoding = None
+
     if len(args) == 3:
         disambiguation, encoding, n = args
-    elif len(args) == 2:
-        disambiguation, n = args
-        encoding = None
     else:
-        raise TypeError(
-            "Expected 4 or 5 arguments, got {0}.".format(len(args) + 2))
+        disambiguation = get_arg(0)
+        n_or_encoding = get_arg(1)
 
-    if hasattr(Qt.QtCore, "QCoreApplication"):
-        app = getattr(Qt.QtCore, "QCoreApplication")
-    else:
-        raise NotImplementedError(
-            "Missing QCoreApplication implementation for {binding}".format(
-                binding=Qt.__binding__,
-            )
-        )
+        if isinstance(n_or_encoding, int):
+            n = n_or_encoding
+        else:
+            encoding = n_or_encoding
+
     if Qt.__binding__ in ("PySide2", "PyQt5"):
         sanitized_args = [context, sourceText, disambiguation, n]
     else:
@@ -856,8 +864,9 @@ def _translate(context, sourceText, *args):
             sourceText,
             disambiguation,
             encoding or app.CodecForTr,
-            n
+            n,
         ]
+
     return app.translate(*sanitized_args)
 
 

--- a/Qt.py
+++ b/Qt.py
@@ -834,7 +834,11 @@ def _translate(context, sourceText, *args):
     try:
         app = getattr(Qt.QtCore, "QCoreApplication")
     except AttributeError:
-        raise NotImplementedError("Missing QCoreApplication implementation for {}".format(Qt.__binding__))
+        raise NotImplementedError(
+            "Missing QCoreApplication implementation for {}".format(
+                Qt.__binding__
+            )
+        )
 
     def get_arg(index):
         try:

--- a/Qt.py
+++ b/Qt.py
@@ -832,7 +832,7 @@ def _translate(context, sourceText, *args):
     # The last argument is n[int]
     # The middle argument can be encoding[QtCore.QCoreApplication.Encoding]
     try:
-        app = getattr(Qt.QtCore, "QCoreApplication")
+        app = Qt.QtCore.QCoreApplication
     except AttributeError:
         raise NotImplementedError(
             "Missing QCoreApplication implementation for {}".format(


### PR DESCRIPTION
In this pull request, I update the logic in `translate()` to allow optional arguments.

I decided to open this pull request after I ran into a ui file compilation difference:

```
pyside2-uic foo.ui --> QCoreApplication.translate("MainWindow", u"MainWindow", None) (pyside-5.15.4)
pyside2-uic foo.ui --> QCoreApplication.translate("MainWindow", u"MainWindow", None, -1) (pyside-5.12.6)
```

Notice how the first compilation with `pyside-5.15.4` returns translate with 3 arguments instead of 4.
When we eventually use `QtCompat.translate()` we run into the following error:

```
  File "/dd/shows/DEV01/user/work.akelada/tools/cent7_64/package/launchpad/0.1.2/python/launchpad/Ui_launchpad_UI.py", line 205, in retranslateUi
    MainWindow.setWindowTitle(QtCompat.translate("MainWindow", u"MainWindow", None))
  File "/dd/tools/cent7_64/package/qt_py/1.3.6/python/Qt.py", line 844, in _translate
    "Expected 4 or 5 arguments, got {0}.".format(len(args) + 2))
TypeError: Expected 4 or 5 arguments, got 3.
```

Now `translate("MainWindow", u"MainWindow", None)` will work since `n` defaults to `-1`.
