### PR TITLE
Updating the `headerToModule` def to only manipulate '.h' files.

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -930,6 +930,11 @@ def _loadUi(uifile, baseinstance=None):
                     Translate a header file to python module path
                     foo/bar.h => foo.bar
                     """
+
+                    if header.endswith(".h") is False:
+                        # Only manipulate header files, identified by the `.h` ext.
+                        return header
+
                     # Remove header extension
                     module = os.path.splitext(header)[0]
 
@@ -944,7 +949,13 @@ def _loadUi(uifile, baseinstance=None):
                 for custom_widget in custom_widgets:
                     class_name = custom_widget.find("class").text
                     header = custom_widget.find("header").text
-                    module = importlib.import_module(headerToModule(header))
+                    try:
+                        header = headerToModule(header)
+                        module = importlib.import_module(header)
+                    except ModuleNotFoundError as _error:
+                        # ReRaising the ModuleNOtFoundError with a more informative
+                        # message to aid in the creation of Tests for this case.
+                        raise ModuleNotFoundError("No module named '%s'" % header)
                     self.custom_widgets[class_name] = getattr(module,
                                                               class_name)
 

--- a/Qt.py
+++ b/Qt.py
@@ -874,23 +874,6 @@ def _translate(context, sourceText, *args):
     return app.translate(*sanitized_args)
 
 
-def _headerToModule(header):
-    """
-    Translate a header file to python module path
-    foo/bar.h => foo.bar
-    """
-
-    # Only manipulate header files, identified by the `.h` ext.
-    if header.endswith(".h") is False:
-        return header
-
-    # Remove header extension
-    module = os.path.splitext(header)[0]
-
-    # Replace os separator by python module separator
-    return module.replace("/", ".").replace("\\", ".")
-
-
 def _loadUi(uifile, baseinstance=None):
     """Dynamically load a user interface from the given `uifile`
 
@@ -942,6 +925,17 @@ def _loadUi(uifile, baseinstance=None):
                 objects. Then we can directly use them in createWidget method.
                 """
 
+                def headerToModule(header):
+                    """
+                    Translate a header file to python module path
+                    foo/bar.h => foo.bar
+                    """
+                    # Remove header extension
+                    module = os.path.splitext(header)[0]
+
+                    # Replace os separator by python module separator
+                    return module.replace("/", ".").replace("\\", ".")
+
                 custom_widgets = etree.find("customwidgets")
 
                 if custom_widgets is None:
@@ -950,7 +944,14 @@ def _loadUi(uifile, baseinstance=None):
                 for custom_widget in custom_widgets:
                     class_name = custom_widget.find("class").text
                     header = custom_widget.find("header").text
-                    module = importlib.import_module(_headerToModule(header))
+
+                    try:
+                        # try to import the module using the header as defined by the user
+                        module = importlib.import_module(header)
+                    except ImportError:
+                        # try again, but use the customized conversion of a path to a module
+                        module = importlib.import_module(headerToModule(header))
+
                     self.custom_widgets[class_name] = getattr(module,
                                                               class_name)
 

--- a/Qt.py
+++ b/Qt.py
@@ -952,10 +952,10 @@ def _loadUi(uifile, baseinstance=None):
                     try:
                         header = headerToModule(header)
                         module = importlib.import_module(header)
-                    except ModuleNotFoundError as _error:
-                        # ReRaising the ModuleNOtFoundError with a more informative
+                    except ImportError as _error:
+                        # ReRaising the ImportError with a more informative
                         # message to aid in the creation of Tests for this case.
-                        raise ModuleNotFoundError("No module named '%s'" % header)
+                        raise ImportError("No module named '%s'" % header)
                     self.custom_widgets[class_name] = getattr(module,
                                                               class_name)
 

--- a/Qt.py
+++ b/Qt.py
@@ -874,6 +874,23 @@ def _translate(context, sourceText, *args):
     return app.translate(*sanitized_args)
 
 
+def _headerToModule(header):
+    """
+    Translate a header file to python module path
+    foo/bar.h => foo.bar
+    """
+
+    # Only manipulate header files, identified by the `.h` ext.
+    if header.endswith(".h") is False:
+        return header
+
+    # Remove header extension
+    module = os.path.splitext(header)[0]
+
+    # Replace os separator by python module separator
+    return module.replace("/", ".").replace("\\", ".")
+
+
 def _loadUi(uifile, baseinstance=None):
     """Dynamically load a user interface from the given `uifile`
 
@@ -925,22 +942,6 @@ def _loadUi(uifile, baseinstance=None):
                 objects. Then we can directly use them in createWidget method.
                 """
 
-                def headerToModule(header):
-                    """
-                    Translate a header file to python module path
-                    foo/bar.h => foo.bar
-                    """
-
-                    if header.endswith(".h") is False:
-                        # Only manipulate header files, identified by the `.h` ext.
-                        return header
-
-                    # Remove header extension
-                    module = os.path.splitext(header)[0]
-
-                    # Replace os separator by python module separator
-                    return module.replace("/", ".").replace("\\", ".")
-
                 custom_widgets = etree.find("customwidgets")
 
                 if custom_widgets is None:
@@ -949,13 +950,7 @@ def _loadUi(uifile, baseinstance=None):
                 for custom_widget in custom_widgets:
                     class_name = custom_widget.find("class").text
                     header = custom_widget.find("header").text
-                    try:
-                        header = headerToModule(header)
-                        module = importlib.import_module(header)
-                    except ImportError as _error:
-                        # ReRaising the ImportError with a more informative
-                        # message to aid in the creation of Tests for this case.
-                        raise ImportError("No module named '%s'" % header)
+                    module = importlib.import_module(_headerToModule(header))
                     self.custom_widgets[class_name] = getattr(module,
                                                               class_name)
 

--- a/tests.py
+++ b/tests.py
@@ -449,25 +449,10 @@ def test_load_ui_customwidget():
     app.exit()
 
 
-def _rewrite_file(file, current, provided):
-    with open(file, "r") as f:
-        new = f.read().replace(
-            "<header>" + current + "</header>",
-            "<header>" + provided + "</header>"
-        )
-    with open(self.ui_qpycustomwidget, "w") as f:
-        f.write(new)
-
-
-def test_load_ui_pycustomwidget():
-    """Tests to see if loadUi loads a custom widget from different sources,
-    such as a Python path or a .h path can be parsed properly.
-
-    The structure of the current code does not provide direct access to the
-    headertomodule function. Instead, the test updates the temp.ui file to
-    contain a different header and tries to load the UI. All cases are
-    designed to trigger a ModuleImport Exception which reports the path
-    expected.
+def test_headerToModule():
+    """
+    Tests to see if headerToModule manipulates the path passed in appropriately.
+    - It should only affect `Header` files and paths, marked with an .h extension.
     """
 
     path_tests = {
@@ -489,30 +474,13 @@ def test_load_ui_pycustomwidget():
         "path/to/module": "path/to/module",
         "module.py": "module.py",
     }
-    import sys
-    from Qt import QtWidgets, QtCompat
 
-    app = QtWidgets.QApplication(sys.argv)
-    win = QtWidgets.QMainWindow()
+    import Qt
 
-    current = "tests"
     for provided, expected in path_tests.items():
-        _rewrite_file(self.ui_qpycustomwidget, current, provided)
-        current = provided
+        result = Qt._headerToModule(provided)
+        assert result == expected, "Provided: %s expected: %s got: %s" % (provided, expected, result)
 
-        try:
-            # actual test
-            QtCompat.loadUi(self.ui_qpycustomwidget, win)
-
-        except ImportError as error:
-            # Since the loadUi is a blackbox it is not possible to test the
-            # `headertomodule` function directly. Test if the ImportError
-            # error contains the correct import path.
-            result = str(error).split("'")[1]
-            assert result == expected, (
-                    "Provided: %s expected: %s got: %s" % (provided, expected, result)
-            )
-    app.exit()
 
 def test_load_ui_invalidpath():
     """Tests to see if loadUi successfully fails on invalid paths"""

--- a/tests.py
+++ b/tests.py
@@ -469,7 +469,6 @@ def test_load_ui_pycustomwidget():
     # create a python file for the custom widget in a directory relative to the tempdir
     filename = os.path.join(
         self.tempdir,
-        self.tempdir,
         "custom",
         "customwidget",
         "customwidget.py"
@@ -478,10 +477,15 @@ def test_load_ui_pycustomwidget():
     with io.open(filename, "w", encoding="utf-8") as f:
         f.write(self.python_custom_widget)
 
+    # Python 2.7 requires that each folder be a package
+    with io.open(os.path.join(self.tempdir, "custom/__init__.py"), "w", encoding="utf-8") as f:
+        f.write(u"")
+    with io.open(os.path.join(self.tempdir, "custom/customwidget/__init__.py"), "w", encoding="utf-8") as f:
+        f.write(u"")
     # append the path to ensure the future import can be loaded 'relative' to the tempdir
     sys.path.append(self.tempdir)
 
-    app = QtWidgets.QApplication([self.tempdir, ])
+    app = QtWidgets.QApplication(sys.argv)
     win = QtWidgets.QMainWindow()
 
     QtCompat.loadUi(self.ui_qpycustomwidget, win)

--- a/tests.py
+++ b/tests.py
@@ -273,7 +273,7 @@ qpycustomwidget_ui = u"""\
 </ui>
 """
 
-python_custom_widget = '''
+python_custom_widget = u'''
 def CustomWidget(parent=None):
     """
     Wrap CustomWidget class into a function to avoid global Qt import

--- a/tests.py
+++ b/tests.py
@@ -309,8 +309,8 @@ def setup():
     self.ui_qpycustomwidget = saveUiFile("qpycustomwidget.ui", qpycustomwidget_ui)
 
 def teardown():
-    # shutil.rmtree(self.tempdir)
-    pass
+    shutil.rmtree(self.tempdir)
+
 
 
 def binding(binding):

--- a/tests.py
+++ b/tests.py
@@ -470,8 +470,6 @@ def test_load_ui_pycustomwidget():
     expected.
     """
 
-    from Qt import QtCompat
-
     path_tests = {
         # Input: Expected
 
@@ -491,6 +489,11 @@ def test_load_ui_pycustomwidget():
         "path/to/module": "path/to/module",
         "module.py": "module.py",
     }
+    import sys
+    from Qt import QtWidgets, QtCompat
+
+    app = QtWidgets.QApplication(sys.argv)
+    win = QtWidgets.QMainWindow()
 
     current = "tests"
     for provided, expected in path_tests.items():
@@ -499,7 +502,7 @@ def test_load_ui_pycustomwidget():
 
         try:
             # actual test
-            QtCompat.loadUi(self.ui_qpycustomwidget)
+            QtCompat.loadUi(self.ui_qpycustomwidget, win)
 
         except ImportError as error:
             # Since the loadUi is a blackbox it is not possible to test the
@@ -509,7 +512,7 @@ def test_load_ui_pycustomwidget():
             assert result == expected, (
                     "Provided: %s expected: %s got: %s" % (provided, expected, result)
             )
-
+    app.exit()
 
 def test_load_ui_invalidpath():
     """Tests to see if loadUi successfully fails on invalid paths"""

--- a/tests.py
+++ b/tests.py
@@ -501,11 +501,11 @@ def test_load_ui_pycustomwidget():
             # actual test
             QtCompat.loadUi(self.ui_qpycustomwidget)
 
-        except ModuleNotFoundError as error:
+        except ImportError as error:
             # Since the loadUi is a blackbox it is not possible to test the
-            # `headertomodule` function directly. Test if the moduleimport
+            # `headertomodule` function directly. Test if the ImportError
             # error contains the correct import path.
-            result = error.msg.split("'")[1]
+            result = str(error).split("'")[1]
             assert result == expected, (
                     "Provided: %s expected: %s got: %s" % (provided, expected, result)
             )


### PR DESCRIPTION
https://github.com/mottosso/Qt.py/issues/401

This is an attempt to have the least amount of impact on the existing functionality, and allow Python custom widgets paths to work.   

The original `header` authored by the user will always be attempted first.  If it fails to import for the PySide implementation, a second attempt is made using the original Qt.py `headerToModule` function.
