### PR TITLE
Add QtCore.QSortFilterProxyModel to PyQt5 in _misplaced_members

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -1018,6 +1018,7 @@ _misplaced_members = {
         "sip.isdeleted": ["QtCompat.isValid", _isvalid],
         "QtWidgets.qApp": "QtWidgets.QApplication.instance()",
         "QtGui.QRegExpValidator": "QtGui.QRegExpValidator",
+        "QtCore.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
         "QtCore.QRegExp": "QtCore.QRegExp",
         "QtCore.QCoreApplication.translate": [
             "QtCompat.translate", _translate


### PR DESCRIPTION
QtCore.QSortFilterProxyModel was removed from `_misplaced_members['PyQt5']` in the latest release.