### PR TITLE
Adding exec method to QtCompat

### DIFF
--- a/Qt-stubs/QtCompat.pyi
+++ b/Qt-stubs/QtCompat.pyi
@@ -16,6 +16,9 @@ class QHeaderView:
 def delete(obj: object) -> None: ...
 
 
+def exec_(obj: object) -> int: ...
+
+
 def getCppPointer(obj: object) -> typing.Tuple[int, ...]: ...
 
 

--- a/Qt.py
+++ b/Qt.py
@@ -1069,6 +1069,22 @@ def _fromStringQt5(func):
     return wrapper
 
 
+def _exec(object):
+    """Start the event loop of the app.
+
+    Usage:
+        See :func:`QtCompat.exec()`
+
+    Arguments:
+        object (QObject): QApplication to execute.
+
+    """
+    if Qt.IsPyQt4 or Qt.IsPySide or Qt.IsPySide2 or Qt.IsPyQt5:
+        return object.exec_()
+    elif Qt.IsPySide6:
+        return getattr(object, "exec")()
+
+
 """Misplaced members
 
 These members from the original submodule are misplaced relative PySide2
@@ -1771,6 +1787,7 @@ def _pyside6():
     if hasattr(Qt, "_QtWidgets"):
         Qt.QtCompat.setSectionResizeMode = \
             Qt._QtWidgets.QHeaderView.setSectionResizeMode
+        Qt.QtCompat.exec_ = _exec
 
     def setWeight(func):
         def wrapper(self, weight):


### PR DESCRIPTION
Adding exec_ as a QtCompat. While it isn't removed in PySide6 it is currently emitting a Deprecation warning. I am unsure when it is slated for removal.

```
D:\...\__main__.py:61: DeprecationWarning: 'exec_' will be removed in the future. Use 'exec' instead.
  sys.exit(app.exec_())
```

Current usage.
```python
app = QtWidgets.QApplication(sys.argv)
window = Window()
window.show()
sys.exit(app.exec_())
```

Suggested usage with QtCompat
```python
app = QtWidgets.QApplication(sys.argv)
window = Window()
window.show()
sys.exit(QtCompat.exec_(app))
```
