### PR TITLE
Enable using Qt_convert_enum.py for enum regression checking

### DIFF
--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -427,3 +427,7 @@ enums that need replaced in each file.
 
 To actually update the code add `--write` flag. This updates existing files and
 does not make backups of the existing files, so make sure to do that first.
+
+To check for enum use regression you can add `--check`. This will change the return
+code to the number of enums that require changing. A return code of zero indicates
+that no enum changes are required.

--- a/tests.py
+++ b/tests.py
@@ -1648,10 +1648,33 @@ if binding("PySide2") and sys.version_info >= (3, 7):
 
         assert enum_check in output
 
+        # Check using the "--check" command outputs the same text but uses
+        # the return code for the number of enums being changed.
+        try:
+            output = subprocess.check_output(
+                cmd + ["--check"], cwd=self.tempdir, universal_newlines=True
+            )
+        except subprocess.CalledProcessError as error:
+            assert error.returncode == 6
+            assert error.stdout == output
+            # The number of changes are added to the end of the output
+            assert "6 enums require changes." in output
+
         # Test actually updating the files.
         cmd.append("--write")
         output = subprocess.check_output(cmd, cwd=self.tempdir, universal_newlines=True)
         assert enum_check in output
+
+        # "--check" is respected in --write mode
+        try:
+            output = subprocess.check_output(
+                cmd + ["--check"], cwd=self.tempdir, universal_newlines=True
+            )
+        except subprocess.CalledProcessError as error:
+            assert error.returncode == 6
+            assert error.stdout == output
+            # The number of changes are added to the end of the output
+            assert "6 enums changed." in output
 
         check = enum_file_1.replace("WindowActive", "WindowState.WindowActive")
         check = check.replace("Box", "Shape.Box")


### PR DESCRIPTION
If you add `--check` to `Qt_convert_enum.py` it will return the number of enums that need/were fixing. This can be used for code quality tests to ensure that new code doesn't accidentally revert to the old [short enum names](https://github.com/mottosso/Qt.py/blob/master/CAVEATS.md#fully-qualified-enums).