### PR TITLE
Add __binding__ to type stubs

### DIFF
--- a/Qt-stubs/__init__.pyi
+++ b/Qt-stubs/__init__.pyi
@@ -1,4 +1,4 @@
-
+__binding__: str
 __qt_version__: str
 IsPyQt5: bool
 IsPyQt4: bool


### PR DESCRIPTION
Fixes #442

I could have used `Literal` here to specify exactly which strings are valid, but I couldn't think of a good use case for the extra complexity. So I've kept is simple and defined it as `str`.