### PR TITLE
Use print instead of sys.stdout/err for _log and _warn

### DIFF
--- a/src/Qt.py
+++ b/src/Qt.py
@@ -2133,17 +2133,17 @@ def _none():
 
 def _log(text):
     if QT_VERBOSE:
-        sys.stdout.write("Qt.py [info]: %s\n" % text)
+        print("Qt.py [info]: %s" % text)
 
 
 def _warn(text):
     try:
-        sys.stderr.write("Qt.py [warning]: %s\n" % text)
+        print(f"Qt.py [warning]: {text}", file=sys.stderr)
     except UnicodeDecodeError:
         import locale
 
         encoding = locale.getpreferredencoding()
-        sys.stderr.write("Qt.py [warning]: %s\n" % text.decode(encoding))
+        print(f"Qt.py [warning]: {text.decode(encoding)}", file=sys.stderr)
 
 
 def _convert(lines):


### PR DESCRIPTION
For windows based non-console apps sys.stderr can be None which causes a silent error. Switching to print accounts for this.

This prevents errors like this.

```py
Traceback (most recent call last):
  File "C:\blur\dev\qt_py\src\Qt.py", line 1761, in _setup
    submodule = _import_sub_module(module, name)
  File "C:\blur\dev\qt_py\src\Qt.py", line 1737, in _import_sub_module
    module = __import__(module.__name__ + "." + name)
ImportError: DLL load failed while importing QtQuick: The specified procedure could not be found.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\blur\dev\qt_py\src\Qt.py", line 1766, in _setup
    submodule = __import__(name)
ModuleNotFoundError: No module named 'QtQuick'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\blur/freezer/plugins\managecannedbatchjobs.py", line 4, in <module>
    from Qt.QtCore import Qt
  File "C:\blur\dev\qt_py\src\Qt.py", line 2408, in <module>
    _install()
  File "C:\blur\dev\qt_py\src\Qt.py", line 2344, in _install
    available[name]()
  File "C:\blur\dev\qt_py\src\Qt.py", line 2096, in _pyqt5
    _setup(module, [])
  File "C:\blur\dev\qt_py\src\Qt.py", line 1768, in _setup
    _warn_import_error(e, name)
  File "C:\blur\dev\qt_py\src\Qt.py", line 1752, in _warn_import_error
    _warn("ImportError(%s): %s" % (module, msg))
  File "C:\blur\dev\qt_py\src\Qt.py", line 2158, in _warn
    sys.stderr.write
AttributeError: 'NoneType' object has no attribute 'write'
```

I used this code to allow me to capture the error without a console.
```py
import sys
import traceback

def except_hook(*exc_info):
    f = open("C:/temp/test.log", "w")
    traceback.print_exception(*exc_info, file=f)

sys.excepthook = except_hook
```