### PR TITLE
Update to ruff==0.15.0 and pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,9 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-    "ruff",
-    "tox>=4,<5"
+    "mypy==1.19.1",
+    "ruff==0.15.0",
+    "tox>=4,<5",
 ]
 
 [project.readme]

--- a/src/Qt.py
+++ b/src/Qt.py
@@ -1948,10 +1948,8 @@ def _pyside6():
 
     if hasattr(Qt, "_QtCore"):
         Qt.__qt_version__ = Qt._QtCore.qVersion()
-        Qt.QtCompat.dataChanged = (
-            lambda self, topleft, bottomright, roles=None: self.dataChanged.emit(
-                topleft, bottomright, roles or []
-            )
+        Qt.QtCompat.dataChanged = lambda self, topleft, bottomright, roles=None: (
+            self.dataChanged.emit(topleft, bottomright, roles or [])
         )
 
     if hasattr(Qt, "_QtWidgets"):
@@ -2018,10 +2016,8 @@ def _pyside2():
 
     if hasattr(Qt, "_QtCore"):
         Qt.__qt_version__ = Qt._QtCore.qVersion()
-        Qt.QtCompat.dataChanged = (
-            lambda self, topleft, bottomright, roles=None: self.dataChanged.emit(
-                topleft, bottomright, roles or []
-            )
+        Qt.QtCompat.dataChanged = lambda self, topleft, bottomright, roles=None: (
+            self.dataChanged.emit(topleft, bottomright, roles or [])
         )
 
     if hasattr(Qt, "_QtWidgets"):
@@ -2059,10 +2055,8 @@ def _pyqt6():
     if hasattr(Qt, "_QtCore"):
         Qt.__binding_version__ = Qt._QtCore.PYQT_VERSION_STR
         Qt.__qt_version__ = Qt._QtCore.QT_VERSION_STR
-        Qt.QtCompat.dataChanged = (
-            lambda self, topleft, bottomright, roles=None: self.dataChanged.emit(
-                topleft, bottomright, roles or []
-            )
+        Qt.QtCompat.dataChanged = lambda self, topleft, bottomright, roles=None: (
+            self.dataChanged.emit(topleft, bottomright, roles or [])
         )
 
     if hasattr(Qt, "_QtWidgets"):
@@ -2094,10 +2088,8 @@ def _pyqt5():
     if hasattr(Qt, "_QtCore"):
         Qt.__binding_version__ = Qt._QtCore.PYQT_VERSION_STR
         Qt.__qt_version__ = Qt._QtCore.QT_VERSION_STR
-        Qt.QtCompat.dataChanged = (
-            lambda self, topleft, bottomright, roles=None: self.dataChanged.emit(
-                topleft, bottomright, roles or []
-            )
+        Qt.QtCompat.dataChanged = lambda self, topleft, bottomright, roles=None: (
+            self.dataChanged.emit(topleft, bottomright, roles or [])
         )
 
     if hasattr(Qt, "_QtWidgets"):

--- a/tox.ini
+++ b/tox.ini
@@ -185,11 +185,11 @@ commands =
     examples: python -m nose2 --verbose examples.QtSiteConfig_platforms.main
 
 [testenv:check]
-deps = ruff
+deps = ruff==0.15.0
 commands = ruff check --output-format concise .
 
 [testenv:format]
-deps = ruff
+deps = ruff==0.15.0
 commands = ruff format --exit-non-zero-on-format .
 
 [testenv:mypy]


### PR DESCRIPTION
The new version of ruff changed its code formatting causing the test to fail. This pins it to the current version. Also add mypy requirement to `[dev]`.