### PR TITLE
Ensure multi-destination misplaced members are implemented for all bindings

### DIFF
--- a/.github/actions/setup-tox/action.yml
+++ b/.github/actions/setup-tox/action.yml
@@ -63,9 +63,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      # NOTE: The virtualenv and tox requirements support finding python 3.7,
-      # if we drop support for python 3.7 the reqs can be simplified and updated
       run: |
         python --version
         python -m pip install --upgrade pip
-        python -m pip install "tox<=4.23.2" "virtualenv<=20.26.6"
+        python -m pip install tox

--- a/.github/actions/setup-tox/action.yml
+++ b/.github/actions/setup-tox/action.yml
@@ -27,37 +27,37 @@ runs:
 
     # Note: The last python to get setup becomes the default for future python calls
     - name: Setup Python 3.7
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.7'
 
     - name: Setup Python 3.9
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.9'
 
     - name: Setup Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
     - name: Setup Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
     - name: Setup Python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
 
     - name: Setup Python 3.14
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.14'
 
     - name: Setup Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10.x"
       - name: Install build dependency

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup tox
         uses: ./.github/actions/setup-tox
@@ -34,7 +34,7 @@ jobs:
           ls -lha .members
 
       - name: Upload membership report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: membership-report
           path: |
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup tox
         uses: ./.github/actions/setup-tox
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup tox
         uses: ./.github/actions/setup-tox
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup tox
         uses: ./.github/actions/setup-tox
@@ -120,14 +120,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup tox
         uses: ./.github/actions/setup-tox
 
       - name: Download coverage artifacts
         # This is needed by the test_membership test
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: membership-report
           path: .members
@@ -157,9 +157,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10.x"
       - name: Install build dependency
@@ -167,7 +167,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Upload packages.
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: pip-packages
           path: |

--- a/tests.py
+++ b/tests.py
@@ -1259,14 +1259,30 @@ def test_misplaced():
     import Qt
 
     assert Qt.QtWidgets.QFileSystemModel
+
     # Members moved from QtWidgets to QtGui with Qt6 are available from both locations
-    assert Qt.QtGui.QAction
-    assert Qt.QtGui.QAction == Qt.QtWidgets.QAction  # type: ignore
-    assert Qt.QtGui.QActionGroup == Qt.QtWidgets.QActionGroup  # type: ignore
-    assert Qt.QtGui.QShortcut == Qt.QtWidgets.QShortcut  # type: ignore
-    assert Qt.QtGui.QUndoCommand == Qt.QtWidgets.QUndoCommand  # type: ignore
-    assert Qt.QtGui.QUndoGroup == Qt.QtWidgets.QUndoGroup  # type: ignore
-    assert Qt.QtGui.QUndoStack == Qt.QtWidgets.QUndoStack  # type: ignore
+    def from_dot_str(name) -> Qt.QtCore.QObject:
+        """Get the object stored on Qt.{name}."""
+        ret = Qt
+        for part in name.split("."):
+            ret = getattr(ret, part)
+        return ret  # type: ignore[return-value]
+
+    # Gather all multi-destination misplaced members for all bindings
+    multi_dests: dict[str, set] = {}
+    for binding in Qt._misplaced_members.values():  # type: ignore
+        for src, dests in binding.items():
+            if isinstance(dests, list) and dests[0] is True:
+                multi_dests.setdefault(src, set()).update(dests[1:])
+
+    # Verify that the current binding has access to all multi-destinations
+    # This effectively does this comparison
+    #   `assert Qt.QtGui.QAction == Qt.QtWidgets.QAction`
+    for src, dests in multi_dests.items():
+        src_obj = from_dot_str(src)
+        for dest in dests:
+            dest_obj = from_dot_str(dest)
+            assert src_obj == dest_obj, f"Checking {src} <> {dest}"
 
 
 def test__extras__():

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ envlist =
     # Cy2024, Cy2025
     test-py311-{PySide,PyQt}6.5-{impl,caveats,examples}
     # Cy2026
-    test-py313-{PySide,PyQt}6.8
+    test-py313-{PySide,PyQt}6.8-{impl,caveats,examples}
     # Test newer versions of python/Qt than VFX Reference Platform has chosen
     test-py{312}-{PySide,PyQt}{6.8}-{impl,caveats,examples}
     test-py{314}-{PySide,PyQt}{6.9}-{impl,caveats,examples}
@@ -55,6 +55,11 @@ envlist =
     mypy
 
 skip_missing_interpreters = True
+requires =
+    # NOTE: The virtualenv and tox requirements support finding python 3.7,
+    # if we drop support for python 3.7 the reqs can be simplified and updated.
+    tox<=4.23.2
+    virtualenv<=20.26.6
 
 [testenv]
 # These are used by all other testenv definitions unless overridden


### PR DESCRIPTION
- Re-works the test_misplaced test to find any multi-destination misplaced member bindings in any binding and ensure that all destinations are implemented in all bindings. This ensures that if a dev adds a new one to the bindings they care about the rest won't miss it.
- Re-worked the tox and virtualenv pinning that ensures python 3.7 can be tested.
- Correctly call the Cy2026 tests names.